### PR TITLE
Drop removed funcs

### DIFF
--- a/tc-ja-alnum.el
+++ b/tc-ja-alnum.el
@@ -65,7 +65,7 @@
 
 ;;;###autoload
 (defun tcode-use-2byte-alnum (package-name &rest libraries)
-  (setq inactivate-current-input-method-function 'tcode-2byte-alnum-inactivate
+  (setq deactivate-current-input-method-function 'tcode-2byte-alnum-inactivate
 	describe-current-input-method-function nil
 	current-input-method package-name)
   (tcode-2byte-alnum-mode 1))

--- a/tc-ja-alnum.el
+++ b/tc-ja-alnum.el
@@ -53,7 +53,7 @@
       (unwind-protect
 	  (progn
 	    (setq tcode-2byte-alnum-mode nil)
-	    (run-hooks 'input-method-inactivate-hook))
+	    (run-hooks 'input-method-deactivate-hook))
 	(setq input-method-function nil))
     ;; activate T-Code mode
     (setq tcode-2byte-alnum-mode t)

--- a/tc-mazegaki.el
+++ b/tc-mazegaki.el
@@ -91,7 +91,7 @@ nil の場合には保存されない。")
       nil
     (prog1
 	(make-face 'mazegaki-conversion)
-      (set-face-underline-p 'mazegaki-conversion t)))
+      (set-face-underline 'mazegaki-conversion t)))
   "* 交ぜ書き変換の変換対象を表す文字列に用いるface。
 mule2 以上または XEmacs の場合のみ有効。")
 (defvar tcode-mazegaki-prefix-overlay nil)

--- a/tc.el
+++ b/tc.el
@@ -1142,7 +1142,7 @@ Tコードモードについては、\\[tcode-mode-help] で表示されるヘ�
 	    (setq tcode-mode nil
 		  tcode-self-insert-non-undo-count 1)
 	    (tcode-clear)
-	    (run-hooks 'input-method-inactivate-hook))
+	    (run-hooks 'input-method-deactivate-hook))
 	(setq input-method-function nil))
     ;; activate T-Code mode
     (if (window-minibuffer-p (selected-window))

--- a/tc.el
+++ b/tc.el
@@ -1201,7 +1201,7 @@ The remaining arguments are libraries to be loaded before using the package."
 	(setq libraries (cdr libraries)))
       (tcode-load-table table-name))
     (setq tcode-current-package package-name))
-  (setq inactivate-current-input-method-function 'tcode-inactivate
+  (setq deactivate-current-input-method-function 'tcode-inactivate
 	describe-current-input-method-function 'tcode-mode-help)
   (setq current-input-method-title 'tcode-mode-indicator)
   (tcode-activate))


### PR DESCRIPTION
For issue #17 

emacs 24で削除された関数・変数の書きかえを行います。
