### PR TITLE
fix compiler warning; forward-line, mapc

### DIFF
--- a/eelll.el
+++ b/eelll.el
@@ -364,7 +364,7 @@ Tコードで入力できなければnilを返す。"
 	  (delete-horizontal-space)
 	  (insert "\n"))
 	(if (< i 4) (insert "\n"))))
-    (mapcar
+    (mapc
      (lambda (c)
        (let ((stroke (eelll-stroke-for-char (char-to-string c))))
 	 (when (and stroke
@@ -576,22 +576,22 @@ EELLL 内ではほとんどのコマンドが禁止されています。
 
 (defun eelll-select-chars (text)
   (let ((ret nil))
-    (mapcar (lambda (c)
-	      (let* ((stroke (eelll-stroke-for-char (char-to-string c)))
-		     (1st (car stroke))
-		     (2nd (car (cdr stroke)))
-		     (lks '(0 1 2 3 4
-			      10 11 12 13 14
-			      20 21 22 23 24
-			      30 31 32 33 34))
-		     (rks '(5 6 7 8 9
-			      15 16 17 18 19
-			      25 26 27 28 29
-			      35 36 37 38 39)))
-		(and (memq 1st (if eelll-first-hand rks lks))
-		     (memq 2nd (if eelll-second-hand rks lks))
-		     (setq ret (cons c ret)))))
-	    (string-to-list text))
+    (mapc (lambda (c)
+	    (let* ((stroke (eelll-stroke-for-char (char-to-string c)))
+		   (1st (car stroke))
+		   (2nd (car (cdr stroke)))
+		   (lks '(0 1 2 3 4
+			    10 11 12 13 14
+			    20 21 22 23 24
+			    30 31 32 33 34))
+		   (rks '(5 6 7 8 9
+			    15 16 17 18 19
+			    25 26 27 28 29
+			    35 36 37 38 39)))
+	      (and (memq 1st (if eelll-first-hand rks lks))
+		   (memq 2nd (if eelll-second-hand rks lks))
+		   (setq ret (cons c ret)))))
+	  (string-to-list text))
     (if ret
 	(mapconcat 'char-to-string ret nil)
       "")))
@@ -838,7 +838,7 @@ Emacs内部のcompletionの実装上の問題のため、「?」を
 	       (insert "\n\n")
 	       (forward-char -1)
 	       (point))))
-    (mapcar 'eelll-put-help-char chars)
+    (mapc 'eelll-put-help-char chars)
     (forward-line)))
 
 ;;;

--- a/eelll.el
+++ b/eelll.el
@@ -186,7 +186,7 @@
     (goto-char (point-min))
     (while (and (> max-line 0)
 		(> lines 0))
-      (goto-line (1+ (random lines)))
+      (forward-line (- (1+ (random lines)) (line-number-at-pos)))
       (if (eolp)
 	  (progn
 	    (unless (eobp)
@@ -374,7 +374,7 @@ Tコードで入力できなければnilを返す。"
 		  (fr (/ (car stroke) 10))
 		  (sc (% second 5))
 		  (sr (/ second 10)))
-	     (goto-line (+ (* sr 5) fr 1))
+	     (forward-line (- (+ (* sr 5) fr 1) (line-number-at-pos)))
 	     (move-to-column (+ 4 (* 12 sc) (* 2 fc)
 				(if (> sc (if eelll-second-hand 0 3)) 2 0)))
 	     (tcode-delete-char 1)

--- a/tc-bushu.el
+++ b/tc-bushu.el
@@ -680,10 +680,10 @@ nilでない場合は多い方が優先される。"
   (let* ((bushu-list (apply 'nconc (mapcar 'tcode-bushu-for-char char-list)))
 	 (r (tcode-bushu-superset bushu-list)))
     (catch 'not-found
-      (mapcar (lambda (c)
-		(unless (setq r (delete c r))
-		  (throw 'not-found nil)))
-	      char-list)
+      (mapc (lambda (c)
+	      (unless (setq r (delete c r))
+		(throw 'not-found nil)))
+	    char-list)
       (sort r 'tcode-bushu-less-p))))
 
 (defun tcode-bushu-less-against-seqence-p (char1 char2)
@@ -704,22 +704,22 @@ nilでない場合は多い方が優先される。"
 (defun tcode-bushu-include-all-chars-bushu-p (char char-list)
   (let* ((bushu (tcode-bushu-for-char char))
 	 (new-bushu bushu))
-    (mapcar (lambda (char)
-	      (setq new-bushu 
-		    (tcode-subtract-set new-bushu
-					(tcode-bushu-for-char char))))
-	    char-list)
+    (mapc (lambda (char)
+	    (setq new-bushu 
+		  (tcode-subtract-set new-bushu
+				      (tcode-bushu-for-char char))))
+	  char-list)
     (setq bushu (tcode-subtract-set bushu new-bushu))
     (catch 'false
-      (mapcar (lambda (char)
-		(or (tcode-subtract-set 
-		     bushu
-		     (apply 'nconc 
-			    (mapcar 
-			     'tcode-bushu-for-char
-			     (tcode-subtract-set char-list (list char)))))
-		    (throw 'false nil)))
-	      char-list)
+      (mapc (lambda (char)
+	      (or (tcode-subtract-set 
+		   bushu
+		   (apply 'nconc 
+			  (mapcar 
+			   'tcode-bushu-for-char
+			   (tcode-subtract-set char-list (list char)))))
+		  (throw 'false nil)))
+	    char-list)
       t)))
 
 (defun tcode-bushu-all-compose-set (char-list &optional bushu-list)
@@ -841,7 +841,7 @@ nilでない場合は多い方が優先される。"
 (defun tcode-bushu-common-set (char-list)
   (let ((bushu-list (tcode-bushu-for-char (car char-list))))
     (catch 'not-found
-      (mapcar
+      (mapc
        (lambda (c)
 	 (unless (setq bushu-list
 		       (tcode-intersection bushu-list
@@ -849,10 +849,10 @@ nilでない場合は多い方が優先される。"
 	   (throw 'not-found nil)))
        (cdr char-list))
       (let ((kouho (tcode-bushu-subset bushu-list)))
-	(mapcar (lambda (c)
-		  (if (memq c kouho)
-		      (setq kouho (delq c kouho))))
-		char-list)
+	(mapc (lambda (c)
+		(if (memq c kouho)
+		    (setq kouho (delq c kouho))))
+	      char-list)
 	(sort kouho 'tcode-bushu-less-or-many-p)))))
 
 (defun tcode-bushu-compose-explicitly (char-list)
@@ -912,7 +912,7 @@ nilでない場合は多い方が優先される。"
   "Compose a character from characters in CHAR-LIST.
 See also `tcode-bushu-functions'."
   (catch 'found
-    (mapcar
+    (mapc
      (lambda (function)
        (let ((r (tcode-bushu-funcall function char-list)))
 	 (if r

--- a/tc-help.el
+++ b/tc-help.el
@@ -487,7 +487,7 @@ FOR-HELPがnilでない場合は、直接入力できる字に分解する。"
 
 (defun tcode-help-stroke (loc ch)
   "subroutine of `tcode-draw-stroke-for-char'."
-  (goto-line (1+ (car loc)))
+  (forward-line (- (1+ (car loc)) (line-number-at-pos)))
   (move-to-column (+ (* 2 (cdr loc)) (if (>= (cdr loc) 6) 0 -2)))
   (tcode-delete-char (if (= (char-width (tcode-following-char)) 2) 
 			 1 
@@ -534,7 +534,7 @@ FOR-HELPがnilでない場合は、直接入力できる字に分解する。"
 	(if (and (<= 0 addr) (< addr 40))
 	    (tcode-help-stroke (tcode-get-key-location addr) char)
 	  (setq char (tcode-key-to-help-string addr)))
-	(goto-line (if (= (mod i 2) 0) 3 4))
+	(forward-line (- (if (= (mod i 2) 0) 3 4) (line-number-at-pos)))
 	(end-of-line)
 	(insert "     " char "…第" str "打鍵")
 	(setq i (1+ i)

--- a/tc-help.el
+++ b/tc-help.el
@@ -185,15 +185,15 @@ nil の場合では見つからないような場合でも、non-nil にすれ�
 	      (cl2 (or (tcode-char-list-for-bushu b1)
 		       (if (= (length b1) 1)
 			   b1))))
-	  (mapcar (lambda (c1)
-		    (unless (stringp c1)
-		      (mapcar (lambda (c2)
-				(unless (stringp c2)
-				  (if (= (tcode-bushu-compose-two-chars c1 c2)
-					 char)
-				      (throw 'found (cons c1 c2)))))
-			      cl2)))
-		  cl1))
+	  (mapc (lambda (c1)
+		  (unless (stringp c1)
+		    (mapcar (lambda (c2)
+			      (unless (stringp c2)
+				(if (= (tcode-bushu-compose-two-chars c1 c2)
+				       char)
+				    (throw 'found (cons c1 c2)))))
+			    cl2)))
+		cl1))
 	(setq b2 (nconc b2 (list (car b1))))))))
 
 (defun tcode-decompose-char (kanji &optional for-help)
@@ -221,7 +221,7 @@ FOR-HELPがnilでない場合は、直接入力できる字に分解する。"
 					  (cdr decomposed))))
 			 (catch 'found
 			   ;; 強合成集合を探す。
-			   (mapcar
+			   (mapc
 			    (lambda (c)
 			      (if (tcode-bushu-composed-p kanji
 							  (car decomposed)
@@ -231,7 +231,7 @@ FOR-HELPがnilでない場合は、直接入力できる字に分解する。"
 			    (sort (tcode-bushu-subset bushu-list)
 				  'tcode-bushu-less-p))
 			   ;; 弱合成集合を探す。
-			   (mapcar
+			   (mapc
 			    (lambda (c)
 			      (if (tcode-bushu-composed-p kanji
 							  (car decomposed)
@@ -250,7 +250,7 @@ FOR-HELPがnilでない場合は、直接入力できる字に分解する。"
 					(car decomposed))))
 		       (catch 'found
 			 ;; 強合成集合を探す。
-			 (mapcar
+			 (mapc
 			  (lambda (c)
 			    (if (tcode-bushu-composed-p kanji
 							c
@@ -260,7 +260,7 @@ FOR-HELPがnilでない場合は、直接入力できる字に分解する。"
 			  (sort (tcode-bushu-subset bushu-list)
 				'tcode-bushu-less-p))
 			 ;; 弱合成集合を探す。
-			 (mapcar
+			 (mapc
 			  (lambda (c)
 			    (if (tcode-bushu-composed-p kanji
 							c
@@ -289,7 +289,7 @@ FOR-HELPがnilでない場合は、直接入力できる字に分解する。"
 					  (tcode-bushu-superset bushu2))
 				   'tcode-bushu-less-p))))
 		       (catch 'found
-			 (mapcar
+			 (mapc
 			  (lambda (c1)
 			    (mapcar
 			     (lambda (c2)
@@ -310,7 +310,7 @@ FOR-HELPがnilでない場合は、直接入力できる字に分解する。"
 	  ;; 強差合成集合を探す。
 	  (let ((bushu-list (tcode-bushu-for-char char)))
 	    (catch 'found
-	      (mapcar
+	      (mapc
 	       (lambda (c)
 		 (when (tcode-encode c)
 		   (let ((diff (tcode-subtract-set (tcode-bushu-for-char c)
@@ -747,7 +747,7 @@ The file is updated if it is older than tcode table."
     (tcode-make-LR-block 5 0)
     (insert "\nRR\n")
     (tcode-make-LR-block 5 5)
-    (mapcar
+    (mapc
      (lambda (x)
        (insert "\n" (nth 2 x) "LL\n") (tcode-make-LR-block 0 0 (car x))
        (insert "\n" (nth 2 x) "LR\n") (tcode-make-LR-block 0 5 (car x))

--- a/tc-jiscode.el
+++ b/tc-jiscode.el
@@ -35,7 +35,7 @@
 (defvar tcode-jiscode-map nil)
 (unless tcode-jiscode-map
   (setq tcode-jiscode-map (make-sparse-keymap))
-  (mapcar
+  (mapc
    (lambda (elm)
      (let ((cmd (car elm))
 	   (key (cdr elm)))

--- a/tc-mazegaki.el
+++ b/tc-mazegaki.el
@@ -734,10 +734,10 @@ NOC (候補の数)と CURRENT-OFFSET から現在何番目の表を表示して�
 		  (/ (+ (- noc current-offset) (1- plist-size)) plist-size)))
 	 (whole-table (or (and (catch 'found
 				 ;; 3段目以外を使うことを確かめる。
-				 (mapcar (lambda (e) (if (or (< e 20)
-							(>= e 30))
-						    (throw 'found t)))
-					 tcode-mazegaki-stroke-priority-list)
+				 (mapc (lambda (e) (if (or (< e 20)
+							   (>= e 30))
+						       (throw 'found t)))
+				       tcode-mazegaki-stroke-priority-list)
 				 nil)
 			       (> whole-page 1))
 			  ;; 3段目以外に候補があるか調べる
@@ -1673,7 +1673,7 @@ CONVERSION が nil でないとき、補完後(補完を行った場合のみ)�
 
   (tcode-set-key " " 'tcode-mazegaki-self-insert-or-convert)
 
-  (mapcar
+  (mapc
    (lambda (elm)
      (define-key tcode-mazegaki-map (car elm) (cdr elm)))
    '((" "     . tcode-mazegaki-select-candidate-or-relimit)

--- a/tc.el
+++ b/tc.el
@@ -402,18 +402,18 @@ nil のときは `tcode-mode' から得る。")
 		  i (1+ i)))
 	  (setq list (cons layout (nreverse list))))))
     (let ((i 0))
-      (mapcar (lambda (char)
-		(cond ((null char)
-		       (aset table (- char ? ) -1))
-		      ((and tcode-shift-lowercase
-			    (/= (upcase char) char))
-		       (aset table (- char ? ) i)
-		       (aset table (- (upcase char) ? ) -2))
-		      (t
-		       (aset table (- char ? ) i)))
-		(setq i (1+ i))
-		(if (= i 40) (setq i 100)))
-	      (cdr list)))
+      (mapc (lambda (char)
+	      (cond ((null char)
+		     (aset table (- char ? ) -1))
+		    ((and tcode-shift-lowercase
+			  (/= (upcase char) char))
+		     (aset table (- char ? ) i)
+		     (aset table (- (upcase char) ? ) -2))
+		    (t
+		     (aset table (- char ? ) i)))
+	      (setq i (1+ i))
+	      (if (= i 40) (setq i 100)))
+	    (cdr list)))
     (let ((char ? ))
       (while (<= char ?~)
 	(if (lookup-key tcode-mode-map (char-to-string char))
@@ -667,16 +667,16 @@ t ... cancel"
 	 nil)))
 
 (defun tcode-apply-filters (list)
-  (mapcar (lambda (alist)
-	    (if (eval (car alist))
-		(let ((v (mapcar (lambda (c) (funcall (cdr alist) c))
-				 list)))
-		  (setq list (apply 'nconc
-				    (mapcar (lambda (e) (if (stringp e)
-						       (string-to-list e)
-						     (list e)))
-					    v))))))
-	  tcode-input-filter-functions)
+  (mapc (lambda (alist)
+	  (if (eval (car alist))
+	      (let ((v (mapcar (lambda (c) (funcall (cdr alist) c))
+			       list)))
+		(setq list (apply 'nconc
+				  (mapcar (lambda (e) (if (stringp e)
+						          (string-to-list e)
+						        (list e)))
+					  v))))))
+	tcode-input-filter-functions)
   list)
 
 (defun tcode-input-method (ch)
@@ -1006,9 +1006,9 @@ ARG が nil でないとき、ARG 番目の組に切り替える。"
     (tcode-set-action-to-table prefix new-table)
     (tcode-set-stroke-property new-table nil t prefix)
     ;; コマンドをテーブルに登録する。
-    (mapcar (lambda (elm)
-	      (tcode-set-action-to-table (append prefix (car elm)) (cdr elm)))
-	    tcode-special-commands-alist)
+    (mapc (lambda (elm)
+	    (tcode-set-action-to-table (append prefix (car elm)) (cdr elm)))
+	  tcode-special-commands-alist)
     (setq tcode-special-commands-alist nil) ; free
     ))
 
@@ -1023,9 +1023,9 @@ ARG が nil でないとき、ARG 番目の組に切り替える。"
   (setq tcode-stroke-table (and (> tcode-stroke-table-size 0)
 				(make-vector tcode-stroke-table-size 0)))
   (tcode-load-table-1 filename)
-  (mapcar (lambda (x) (tcode-load-table-1 (nth 1 x)
-					  (car x)))
-	  tcode-special-prefix-alist)
+  (mapc (lambda (x) (tcode-load-table-1 (nth 1 x)
+					(car x)))
+	tcode-special-prefix-alist)
   (let ((l tcode-ext-keys)
 	(i 40))
     (while l
@@ -1350,11 +1350,11 @@ Type \\[tcode-mode-help] for more detail."
 	 draw-table)
      ;; table はリスト
      (let ((draw-table (make-vector 40 nil)))
-       (mapcar (lambda (elm)
-		 (aset draw-table
-		       (car elm)
-		       (tcode-action-to-printable (cdr elm))))
-	       table)
+       (mapc (lambda (elm)
+	       (aset draw-table
+		     (car elm)
+		     (tcode-action-to-printable (cdr elm))))
+	     table)
        draw-table))
    1 1))
 


### PR DESCRIPTION
以下のコンパイラワーニングを解消しました。
```
Warning (bytecomp): "goto-line" is for interactive use only; use "forward-line" instead.
Warning (bytecomp): value from call to "mapcar" is unused; use "mapc" or "dolist" instead
```