### PR TITLE
isearch拡張機能のadviceによる再実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ Windowsは日本語環境にしておいた方が無難です。
 (require 'tc-setup)
 (add-to-list 'default-frame-alist '(font . "-outline-ＭＳ ゴシック-normal-normal-normal-mono-19-*-*-*-c-*-iso8859-1"))
 ```
+
+## isearch実装の選択
+
+isearch機能のT-Code用拡張は、次の2種類の実装から選ぶことができます。機能の内容や使い方は同じです。
+
+ - 従来実装。Emacsの内部関数の書き換えによってisearch拡張を実現しているため、Emacsに最近追加されたisearch機能が使えなくなる場合があります。`(setq tcode-use-isearch 'overwrite)` とすることで利用できます(デフォルト)。
+ - advice機能を用いた実装。Emacs内部関数の書き換えを無くした実装なので、Emacsのバージョンアップによるisearch機能の変化に追従しやすくなっています。`(setq tcode-use-isearch 'advice)` とすることで利用できます。

--- a/tc-is22.el
+++ b/tc-is22.el
@@ -61,13 +61,6 @@
   :group 'tcode)
 
 ;;;
-;;; Default key binding
-;;;
-(when (eq tcode-emacs-version 'xemacs)
-  (define-key isearch-mode-map "\C-\\" 'isearch-toggle-tcode)
-  (put 'isearch-toggle-tcode 'isearch-command t)) ; for XEmacs
-
-;;;
 ;;; patch to original functions in isearch.el of Emacs 22
 ;;;
 
@@ -276,13 +269,6 @@
       (unless normal-end
 	(setq isearch-cmds orig-isearch-cmds)
 	(tcode-isearch-top-state)))))
-
-(defun isearch-toggle-tcode ()
-  "インクリメンタルサーチ中のTコードモードをトグルする。"
-  (interactive)
-  (unless tcode-isearch-start-state
-    (toggle-input-method))
-  (isearch-update))
 
 (defun tcode-isearch-bushu-henkan (c1 c2)
   ;; インクリメンタルサーチ中に C1 と C2 とで部首合成変換する。

--- a/tc-is22.el
+++ b/tc-is22.el
@@ -31,15 +31,12 @@
 ;;;
 ;;;  User Variables
 ;;;
-(defvar tcode-isearch-start-state nil
+(defvar-local tcode-isearch-start-state nil
   "*インクリメンタルサーチ開始時のTコードモードを指定する。
-       nil: バッファのTコードモードに同期(デフォールト)。
-       t:   バッファのTコードモードと独立。開始時はバッファと同じ。
-       0:   バッファと独立に常に非Tコードモードサーチから開始。
-       1:   バッファと独立に常にTコードモードサーチから開始。
+       nil: バッファのTコードモードを引き継ぐ(デフォルト)。
+       0:   開始時、Tコードモードをオフにする。
+       1:   開始時、Tコードモードをオンにする。
 バッファローカル変数。")
-(make-variable-buffer-local 'tcode-isearch-start-state)
-(setq-default tcode-isearch-start-state nil)
 
 (defcustom tcode-isearch-enable-wrapped-search t
   "*2バイト文字でサーチするときに、空白や改行を無視する。"
@@ -386,13 +383,16 @@ STR から `tcode-isearch-ignore-regexp' を取り除く。"
       (tcode-isearch-start-bushu)
     (tcode-isearch-postfix-bushu)))
 
+(defun tcode-isearch-set-im-mode (enable)
+  "isearch 中に、input method の有効化/無効化を行う。"
+  (when (or (and enable (null current-input-method))
+	    (and (not enable) current-input-method))
+    (isearch-toggle-input-method)))
+
 (defun tcode-isearch-init ()
-  "Tコードモードインクリメンタルサーチの初期化を行う。"
-  (setq tcode-mode (if (numberp tcode-isearch-start-state)
-		       (if (zerop tcode-isearch-start-state) nil t)
-		     (and (boundp 'tcode-mode)
-			  tcode-mode)))
-  (isearch-update))
+  "isearch 開始時、input method の状態をセットする。"
+  (when (numberp tcode-isearch-start-state)
+    (tcode-isearch-set-im-mode (not (zerop tcode-isearch-start-state)))))
 
 (add-hook 'isearch-mode-hook 'tcode-isearch-init)
 

--- a/tc-is22.el
+++ b/tc-is22.el
@@ -25,39 +25,10 @@
 
 ;;; Code:
 
+(require 'tc-iscommon)
+
 (if (< (string-to-number emacs-version) 22)
     (error "tc-is22 cannot run on NEmacs/Mule/Emacs20/21.  Use Emacs 22 or later!"))
-
-;;;
-;;;  User Variables
-;;;
-(defvar-local tcode-isearch-start-state nil
-  "*インクリメンタルサーチ開始時のTコードモードを指定する。
-       nil: バッファのTコードモードを引き継ぐ(デフォルト)。
-       0:   開始時、Tコードモードをオフにする。
-       1:   開始時、Tコードモードをオンにする。
-バッファローカル変数。")
-
-(define-obsolete-variable-alias 'tcode-isearch-enable-wrapped-search
-  'tcode-isearch-enable-line-fold-search "2025-12-09")
-(defcustom tcode-isearch-enable-line-fold-search t
-  "*2バイト文字でサーチするときに、空白や改行を無視する。"
-  :type 'boolean :group 'tcode)
-
-(defcustom tcode-isearch-ignore-regexp "[\n \t]*"
-  "* 2バイト文字間に入る正規表現。
-`tcode-isearch-enable-line-fold-search' が t のときのみ有効。"
-  :type 'regexp :group 'tcode)
-
-(defcustom tcode-isearch-special-function-alist
-  '((tcode-bushu-begin-conversion . tcode-isearch-bushu-conversion-command)
-    (tcode-bushu-begin-alternate-conversion
-     . tcode-isearch-bushu-alternate-conversion-command)
-    (tcode-mazegaki-begin-alternate-conversion . tcode-isearch-prefix-mazegaki)
-    (tcode-mazegaki-begin-conversion . tcode-isearch-postfix-mazegaki)
-    (tcode-toggle-alnum-mode))
-  "*isearch中での特殊なコマンドの入力に対する代替コマンドの alist。"
-  :group 'tcode)
 
 ;;;
 ;;; patch to original functions in isearch.el of Emacs 22
@@ -67,20 +38,6 @@
 (defsubst tcode-isearch-regexp-function ()
   (or (bound-and-true-p isearch-regexp-function)
       (bound-and-true-p isearch-word)))
-
-;; isearch-message-state -> isearch--state-message from 24
-(defsubst tcode-isearch--state-message (x)
-  (or (when (fboundp 'isearch--state-message)
-	(isearch--state-message x))
-      (when (fboundp 'isearch-message-state)
-	(isearch-message-state x))))
-
-;; isearch-top-state -> none
-;; -> (isearch--set-state (car isearch-cmds)) from 24
-(defsubst tcode-isearch-top-state ()
-  (or (bound-and-true-p isearch-top-state)
-      (when (fboundp 'isearch--set-state)
-	(isearch--set-state (car isearch-cmds)))))
 
 (defadvice isearch-search-string (around tcode-handling activate)
   (let ((isearch-regexp (if (or (tcode-isearch-regexp-function) isearch-regexp)
@@ -235,69 +192,6 @@
     (unless (string= string "")
       (tcode-isearch-process-string string nil))))
 
-(defun tcode-isearch-prefix-mazegaki ()
-  "インクリメンタルサーチ中に前置型の交ぜ書き変換を行う。"
-  (let* (overriding-terminal-local-map
-	 (minibuffer-setup-hook (lambda ()
-				  (tcode-activate tcode-mode)
-				  (tcode-mazegaki-put-prefix)))
-	 (string (read-string (concat "Isearch read: " isearch-message)
-			      nil nil nil t)))
-    (unless (string= string "")
-      (tcode-isearch-process-string string nil))))
-
-(defun tcode-isearch-postfix-mazegaki ()
-  "インクリメンタルサーチ中に後置型の交ぜ書き変換を行う。"
-  (let ((orig-isearch-cmds isearch-cmds)
-	normal-end)
-    (unwind-protect
-	(let ((current-string isearch-message))
-	  ;; clear isearch states
-	  (while (cdr isearch-cmds)
-	    (isearch-pop-state))
-	  (let* (overriding-terminal-local-map
-		 (minibuffer-setup-hook
-		  (lambda ()
-		    (tcode-activate tcode-mode)
-		    (tcode-mazegaki-begin-conversion nil)))
-		 (string (read-string "Isearch read: "
-				      current-string nil nil t)))
-	    (unless (string= string "")
-	      (tcode-isearch-process-string string nil)
-	      (setq normal-end t))))
-      (unless normal-end
-	(setq isearch-cmds orig-isearch-cmds)
-	(tcode-isearch-top-state)))))
-
-(defun tcode-isearch-bushu-henkan (c1 c2)
-  ;; インクリメンタルサーチ中に C1 と C2 とで部首合成変換する。
-  (let ((c (tcode-bushu-compose-two-chars (string-to-char c1)
-					  (string-to-char c2))))
-    (if c
-	(let ((s (char-to-string c)))
-	  (let ((msg (tcode-isearch--state-message (car isearch-cmds))))
-	    (while (and msg
-			(string= msg (tcode-isearch--state-message (car isearch-cmds))))
-	      (isearch-delete-char)))
-	  (let ((msg (tcode-isearch--state-message (car isearch-cmds))))
-	    (while (and msg
-			(string= msg (tcode-isearch--state-message (car isearch-cmds))))
-	      (isearch-delete-char)))
-	  (isearch-process-search-string
-	   (tcode-isearch-make-string-for-line-fold s) s))
-      (ding)
-      (isearch-update))))
-
-(defun tcode-isearch-process-string (str prev)
-  "文字 STR を検索文字列に加えて検索する。
-PREV と合成できるときはその合成した文字で検索する。"
-  (if (stringp prev)
-      (tcode-isearch-bushu-henkan prev str)
-    (isearch-process-search-string
-     (if prev
-	 ""
-       (tcode-isearch-make-string-for-line-fold str)) str)))
-
 (defun tcode-regexp-unquote (str)
   (let* ((ll (string-to-list str))
 	 (l ll))
@@ -343,58 +237,6 @@ STR から `tcode-isearch-ignore-regexp' を取り除く。"
 	 string-list
 	 nil)
       string)))
-
-(defun tcode-isearch-start-bushu ()
-  "Tコードモードインクリメンタルサーチ中の前置型部首合成変換を始める。"
-  (tcode-bushu-init 2)
-  (setq isearch-message (concat isearch-message "▲"))
-  (isearch-push-state)
-  (isearch-update))
-
-(defun tcode-isearch-postfix-bushu ()
-  "Tコードモードインクリメンタルサーチ中の後置型部首合成変換を始める。"
-  (let ((p1 (string-match "..$" isearch-message))
-	(p2 (string-match ".$"  isearch-message)))
-    (if (null p1)
-	(ding)
-      (tcode-bushu-init 2)
-      (tcode-isearch-bushu-henkan (substring isearch-message p1 p2)
-				  (substring isearch-message p2)))))
-
-(defun tcode-isearch-bushu ()
-  "isearch-message中の部首合成の文字を調べる。"
-  (cond
-   ((string-match "▲$" isearch-message)
-    t)
-   ((string-match "▲.$" isearch-message)
-    (substring isearch-message (string-match ".$" isearch-message)))
-   (t
-    nil)))
-
-(defun tcode-isearch-bushu-alternate-conversion-command ()
-  "isearch中で通常とは逆の型の部首合成変換を始める。"
-  (interactive)
-  (if tcode-use-postfix-bushu-as-default
-      (tcode-isearch-start-bushu)
-    (tcode-isearch-postfix-bushu)))
-
-(defun tcode-isearch-bushu-conversion-command ()
-  "isearch中で部首合成変換を始める。"
-  (interactive)
-  (if (not tcode-use-postfix-bushu-as-default)
-      (tcode-isearch-start-bushu)
-    (tcode-isearch-postfix-bushu)))
-
-(defun tcode-isearch-set-im-mode (enable)
-  "isearch 中に、input method の有効化/無効化を行う。"
-  (when (or (and enable (null current-input-method))
-	    (and (not enable) current-input-method))
-    (isearch-toggle-input-method)))
-
-(defun tcode-isearch-init ()
-  "isearch 開始時、input method の状態をセットする。"
-  (when (numberp tcode-isearch-start-state)
-    (tcode-isearch-set-im-mode (not (zerop tcode-isearch-start-state)))))
 
 (add-hook 'isearch-mode-hook 'tcode-isearch-init)
 

--- a/tc-is22.el
+++ b/tc-is22.el
@@ -38,13 +38,15 @@
        1:   開始時、Tコードモードをオンにする。
 バッファローカル変数。")
 
-(defcustom tcode-isearch-enable-wrapped-search t
+(define-obsolete-variable-alias 'tcode-isearch-enable-wrapped-search
+  'tcode-isearch-enable-line-fold-search "2025-12-09")
+(defcustom tcode-isearch-enable-line-fold-search t
   "*2バイト文字でサーチするときに、空白や改行を無視する。"
   :type 'boolean :group 'tcode)
 
 (defcustom tcode-isearch-ignore-regexp "[\n \t]*"
   "* 2バイト文字間に入る正規表現。
-`tcode-isearch-enable-wrapped-search' が t のときのみ有効。"
+`tcode-isearch-enable-line-fold-search' が t のときのみ有効。"
   :type 'regexp :group 'tcode)
 
 (defcustom tcode-isearch-special-function-alist
@@ -83,7 +85,7 @@
 (defadvice isearch-search-string (around tcode-handling activate)
   (let ((isearch-regexp (if (or (tcode-isearch-regexp-function) isearch-regexp)
                             isearch-regexp
-                          tcode-isearch-enable-wrapped-search)))
+                          tcode-isearch-enable-line-fold-search)))
     ad-do-it))
 
 (defun isearch-printing-char ()
@@ -144,8 +146,8 @@
 (defadvice isearch-process-search-char (around tcode-handling activate)
   "Extention for T-code"
   (if (and (not isearch-regexp)
-	   (boundp 'tcode-isearch-enable-wrapped-search)
-	   tcode-isearch-enable-wrapped-search
+	   (boundp 'tcode-isearch-enable-line-fold-search)
+	   tcode-isearch-enable-line-fold-search
 	   (memq char '(?$ ?* ?+ ?. ?? ?\[ ?\\ ?\] ?^)))
       (let ((s (char-to-string char)))
 	(isearch-process-search-string (concat "\\" s) s))
@@ -168,7 +170,7 @@
       (setq string (downcase string)))
   (if isearch-regexp (setq string (regexp-quote string)))
   (setq isearch-string (concat isearch-string
-			       (tcode-isearch-make-string-for-wrapping string))
+			       (tcode-isearch-make-string-for-line-fold string))
 	isearch-message
 	(concat isearch-message
 		(mapconcat 'isearch-text-char-description string ""))
@@ -282,7 +284,7 @@
 			(string= msg (tcode-isearch--state-message (car isearch-cmds))))
 	      (isearch-delete-char)))
 	  (isearch-process-search-string
-	   (tcode-isearch-make-string-for-wrapping s) s))
+	   (tcode-isearch-make-string-for-line-fold s) s))
       (ding)
       (isearch-update))))
 
@@ -294,7 +296,7 @@ PREV と合成できるときはその合成した文字で検索する。"
     (isearch-process-search-string
      (if prev
 	 ""
-       (tcode-isearch-make-string-for-wrapping str)) str)))
+       (tcode-isearch-make-string-for-line-fold str)) str)))
 
 (defun tcode-regexp-unquote (str)
   (let* ((ll (string-to-list str))
@@ -308,9 +310,9 @@ PREV と合成できるときはその合成した文字で検索する。"
     (mapconcat (function char-to-string) ll nil)))
 
 (defun tcode-isearch-remove-ignore-regexp (str)
-  "変数 `tcode-isearch-enable-wrapped-search' が nil でないとき、
+  "変数 `tcode-isearch-enable-line-fold-search' が nil でないとき、
 STR から `tcode-isearch-ignore-regexp' を取り除く。"
-  (if (or (not tcode-isearch-enable-wrapped-search)
+  (if (or (not tcode-isearch-enable-line-fold-search)
 	  isearch-regexp)
       str
     (let (idx
@@ -322,10 +324,10 @@ STR から `tcode-isearch-ignore-regexp' を取り除く。"
 			  (substring str (+ idx regexp-len) nil))))
       (tcode-regexp-unquote str))))
 
-(defun tcode-isearch-make-string-for-wrapping (string)
+(defun tcode-isearch-make-string-for-line-fold (string)
   (let ((string-list (and string
 			  (string-to-list string))))
-    (if (and tcode-isearch-enable-wrapped-search
+    (if (and tcode-isearch-enable-line-fold-search
 	     (not isearch-regexp)
 	     string-list)
 	(mapconcat

--- a/tc-iscommon.el
+++ b/tc-iscommon.el
@@ -1,0 +1,207 @@
+;;; tc-iscommon.el --- Excerpts from tc-is22.el. -*- lexical-binding: nil -*-
+
+;; Copyright (C) 1994,97-2001, 2005 Kaoru Maeda, Mikihiko Nakao, KITAJIMA Akira and Masayuki Ataka
+
+;; Author: Kaoru Maeda <maeda@src.ricoh.co.jp>
+;;      Mikihiko Nakao
+;;      KITAJIMA Akira <kitajima@isc.osakac.ac.jp>
+;;      Masayuki Ataka <masayuki.ataka@gmail.com>
+;; Maintainer: Masayuki Ataka
+;; Create: 12 Feb (Sat), 2005
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, write to the Free Software
+;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+;;; Commentary:
+
+;;   tc-is22.el から、emacs 本体の関数の置き換えを行わない関数を抜き出
+;;   したもの。
+
+;;; Code:
+
+(declare-function tcode-bushu-init                        "tc")
+(declare-function tcode-activate                          "tc")
+(declare-function tcode-isearch-make-string-for-line-fold "tc-ishelper")
+(declare-function tcode-bushu-compose-two-chars           "tc-bushu")
+(declare-function tcode-mazegaki-begin-conversion         "tc-mazegaki")
+(declare-function tcode-mazegaki-put-prefix               "tc-mazegaki")
+
+(defvar tcode-mode)
+(defvar tcode-use-postfix-bushu-as-default)
+
+;;;
+;;;  User Variables
+;;;
+(defvar-local tcode-isearch-start-state nil
+  "*インクリメンタルサーチ開始時のTコードモードを指定する。
+       nil: バッファのTコードモードを引き継ぐ(デフォルト)。
+       0:   開始時、Tコードモードをオフにする。
+       1:   開始時、Tコードモードをオンにする。
+バッファローカル変数。")
+
+(define-obsolete-variable-alias 'tcode-isearch-enable-wrapped-search
+  'tcode-isearch-enable-line-fold-search "2025-12-09")
+(defcustom tcode-isearch-enable-line-fold-search t
+  "*2バイト文字でサーチするときに、空白や改行を無視する。"
+  :type 'boolean :group 'tcode)
+
+(defcustom tcode-isearch-ignore-regexp "[\n \t]*"
+  "* 2バイト文字間に入る正規表現。
+`tcode-isearch-enable-line-fold-search' が t のときのみ有効。"
+  :type 'regexp :group 'tcode)
+
+;;;
+;;; Implementations
+;;;
+
+(defcustom tcode-isearch-special-function-alist
+  '((tcode-bushu-begin-conversion . tcode-isearch-bushu-conversion-command)
+    (tcode-bushu-begin-alternate-conversion
+     . tcode-isearch-bushu-alternate-conversion-command)
+    (tcode-mazegaki-begin-alternate-conversion . tcode-isearch-prefix-mazegaki)
+    (tcode-mazegaki-begin-conversion . tcode-isearch-postfix-mazegaki)
+    (tcode-toggle-alnum-mode))
+  "*isearch中での特殊なコマンドの入力に対する代替コマンドの alist。"
+  :group 'tcode)
+
+;; isearch-message-state -> isearch--state-message from 24
+(defsubst tcode-isearch--state-message (x)
+  (or (when (fboundp 'isearch--state-message)
+	(isearch--state-message x))
+      (when (fboundp 'isearch-message-state)
+	(isearch-message-state x))))
+
+;; isearch-top-state -> none
+;; -> (isearch--set-state (car isearch-cmds)) from 24
+(defsubst tcode-isearch-top-state ()
+  (or (bound-and-true-p isearch-top-state)
+      (when (fboundp 'isearch--set-state)
+	(isearch--set-state (car isearch-cmds)))))
+
+(defun tcode-isearch-prefix-mazegaki ()
+  "インクリメンタルサーチ中に前置型の交ぜ書き変換を行う。"
+  (let* (overriding-terminal-local-map
+	 (minibuffer-setup-hook (lambda ()
+				  (tcode-activate tcode-mode)
+				  (tcode-mazegaki-put-prefix)))
+	 (string (read-string (concat "Isearch read: " isearch-message)
+			      nil nil nil t)))
+    (unless (string= string "")
+      (tcode-isearch-process-string string nil))))
+
+(defun tcode-isearch-postfix-mazegaki ()
+  "インクリメンタルサーチ中に後置型の交ぜ書き変換を行う。"
+  (let ((orig-isearch-cmds isearch-cmds)
+	normal-end)
+    (unwind-protect
+	(let ((current-string isearch-message))
+	  ;; clear isearch states
+	  (while (cdr isearch-cmds)
+	    (isearch-pop-state))
+	  (let* (overriding-terminal-local-map
+		 (minibuffer-setup-hook
+		  (lambda ()
+		    (tcode-activate tcode-mode)
+		    (tcode-mazegaki-begin-conversion nil)))
+		 (string (read-string "Isearch read: "
+				      current-string nil nil t)))
+	    (unless (string= string "")
+	      (tcode-isearch-process-string string nil)
+	      (setq normal-end t))))
+      (unless normal-end
+	(setq isearch-cmds orig-isearch-cmds)
+	(tcode-isearch-top-state)))))
+
+(defun tcode-isearch-bushu-henkan (c1 c2)
+  ;; インクリメンタルサーチ中に C1 と C2 とで部首合成変換する。
+  (let ((c (tcode-bushu-compose-two-chars (string-to-char c1)
+					  (string-to-char c2))))
+    (if c
+	(let ((s (char-to-string c)))
+	  (let ((msg (tcode-isearch--state-message (car isearch-cmds))))
+	    (while (and msg
+			(string= msg (tcode-isearch--state-message (car isearch-cmds))))
+	      (isearch-delete-char)))
+	  (let ((msg (tcode-isearch--state-message (car isearch-cmds))))
+	    (while (and msg
+			(string= msg (tcode-isearch--state-message (car isearch-cmds))))
+	      (isearch-delete-char)))
+	  (isearch-process-search-string
+	   (tcode-isearch-make-string-for-line-fold s) s))
+      (ding)
+      (isearch-update))))
+
+(defun tcode-isearch-process-string (str prev)
+  "文字 STR を検索文字列に加えて検索する。
+PREV と合成できるときはその合成した文字で検索する。"
+  (if (stringp prev)
+      (tcode-isearch-bushu-henkan prev str)
+    (isearch-process-search-string
+     (if prev
+	 ""
+       (tcode-isearch-make-string-for-line-fold str)) str)))
+
+(defun tcode-isearch-start-bushu ()
+  "Tコードモードインクリメンタルサーチ中の前置型部首合成変換を始める。"
+  (tcode-bushu-init 2)
+  (setq isearch-message (concat isearch-message "▲"))
+  (isearch-push-state)
+  (isearch-update))
+
+(defun tcode-isearch-postfix-bushu ()
+  "Tコードモードインクリメンタルサーチ中の後置型部首合成変換を始める。"
+  (let ((p1 (string-match "..$" isearch-message))
+	(p2 (string-match ".$"  isearch-message)))
+    (if (null p1)
+	(ding)
+      (tcode-bushu-init 2)
+      (tcode-isearch-bushu-henkan (substring isearch-message p1 p2)
+				  (substring isearch-message p2)))))
+
+(defun tcode-isearch-bushu ()
+  "isearch-message中の部首合成の文字を調べる。"
+  (cond
+   ((string-match "▲$" isearch-message)
+    t)
+   ((string-match "▲.$" isearch-message)
+    (substring isearch-message (string-match ".$" isearch-message)))
+   (t
+    nil)))
+
+(defun tcode-isearch-bushu-alternate-conversion-command ()
+  "isearch中で通常とは逆の型の部首合成変換を始める。"
+  (interactive)
+  (if tcode-use-postfix-bushu-as-default
+      (tcode-isearch-start-bushu)
+    (tcode-isearch-postfix-bushu)))
+
+(defun tcode-isearch-bushu-conversion-command ()
+  "isearch中で部首合成変換を始める。"
+  (interactive)
+  (if (not tcode-use-postfix-bushu-as-default)
+      (tcode-isearch-start-bushu)
+    (tcode-isearch-postfix-bushu)))
+
+(defun tcode-isearch-set-im-mode (enable)
+  "isearch 中に、input method の有効化/無効化を行う。"
+  (when (or (and enable (null current-input-method))
+	    (and (not enable) current-input-method))
+    (isearch-toggle-input-method)))
+
+(defun tcode-isearch-init ()
+  "isearch 開始時、input method の状態をセットする。"
+  (when (numberp tcode-isearch-start-state)
+    (tcode-isearch-set-im-mode (not (zerop tcode-isearch-start-state)))))
+
+(provide 'tc-iscommon)

--- a/tc-ishelper.el
+++ b/tc-ishelper.el
@@ -1,0 +1,24 @@
+;;; tc-ishelper.el --- T-Code isearch supports.  -*- lexical-binding: nil -*-
+
+;; Copyright (C) 2025 Github kanchoku/tc contributors
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;   T-Code 用の isearch 拡張機能。ts-is22.el を置き換えるモジュール。
+
+;;; Code:
+
+(provide 'tc-ishelper)

--- a/tc-ishelper.el
+++ b/tc-ishelper.el
@@ -21,4 +21,76 @@
 
 ;;; Code:
 
+(require 'tc-iscommon)
+
+;;;
+;;; advice による isearch 拡張の実装
+;;;
+
+(declare-function tcode-function-p    "tc")
+(declare-function tcode-apply-filters "tc")
+(declare-function tcode-decode-chars  "tc")
+
+(defun tcode--isearch-printing-char (orig-fun &optional char count)
+  "isearch 中に文字キーが押されると呼ばれる。必要に応じて T-Code 実装を呼ぶ。"
+  (if (bound-and-true-p tcode-mode)
+      (tcode--input-method-for-isearch char count)
+    (funcall orig-fun char count)))
+
+;; tc-is22.el の isearch-printing-char の追加部分を抜き出したもの。
+(defun tcode--input-method-for-isearch (char count)
+  "isearch 中の日本語入力。`tcode-input-method'の簡易版。"
+  (let* ((decoded (tcode-decode-chars char))
+	 (action (car decoded))
+	 (prev (tcode-isearch-bushu)))
+    (cond ((null action)
+	   (ding))
+	  ((stringp action)
+	   (setq action
+		 (mapconcat 'char-to-string
+			    (tcode-apply-filters
+			     (string-to-list action))
+			    nil))
+	   (tcode-isearch-process-string action prev))
+	  ((char-or-string-p action)
+	   (tcode-isearch-process-string
+	    (char-to-string (car (tcode-apply-filters (list action))))
+	    prev))
+	  ((and (not (tcode-function-p action))
+		(consp action))
+	   (tcode-isearch-process-string
+	    (mapconcat 'char-to-string
+		       (tcode-apply-filters
+			(mapcar 'string-to-char
+				(delq nil action)))
+		       nil)
+	    prev))
+	  ((tcode-function-p action)
+	   (let ((func (assq action
+			     tcode-isearch-special-function-alist)))
+	     (if func
+		 (funcall (or (cdr func)
+			      action))
+	       (tcode-isearch-process-string
+		(mapconcat 'char-to-string (cdr decoded) nil)
+		prev))))
+	  (t
+	   (ding)))))
+
+;; この関数の役割は tcode--line-fold-search-regexp に移った。
+(defalias 'tcode-isearch-make-string-for-line-fold #'identity)
+
+;;;
+;;; 初期化
+;;;
+
+(defvar tcode-use-isearch)
+
+(defun tcode--ishelper-init ()
+  "tc-ishelper.el のロード時に初期化を行なう。"
+  (when (eq tcode-use-isearch 'advice)
+    (advice-add 'isearch-printing-char :around #'tcode--isearch-printing-char))
+  (add-hook 'isearch-mode-hook #'tcode-isearch-init))
+
+(tcode--ishelper-init)
 (provide 'tc-ishelper)

--- a/tc-pre.el
+++ b/tc-pre.el
@@ -45,8 +45,8 @@
   "日本語Emacsのタイプ。
 mule-1, mule-2, mule-3, mule-4, xemacsのいずれか。")
 
-(defconst tcode-isearch-type 'tc-is22
-  "isearchで用いるTコード用モジュールのタイプ。")
+(defconst tcode-isearch-overwrite-module 'tc-is22
+  "isearch 拡張のために Emacs 内部関数を置き換える関数を提供するモジュール名。")
 
 (defmacro tcode-xemacs-p ()
   (list 'eq 'tcode-emacs-version (list 'quote 'xemacs)))

--- a/tc-pre.el
+++ b/tc-pre.el
@@ -46,7 +46,8 @@
 mule-1, mule-2, mule-3, mule-4, xemacsのいずれか。")
 
 (defconst tcode-isearch-overwrite-module 'tc-is22
-  "isearch 拡張のために Emacs 内部関数を置き換える関数を提供するモジュール名。")
+  "`tcode-use-isearch' が `overwrite' のとき、isearch 拡張のために
+Emacs 内部関数を置き換える関数を提供するモジュール名。")
 
 (defmacro tcode-xemacs-p ()
   (list 'eq 'tcode-emacs-version (list 'quote 'xemacs)))
@@ -72,7 +73,14 @@ mule-1, mule-2, mule-3, mule-4, xemacsのいずれか。")
 設定しなければならない。")
 
 (defvar tcode-use-isearch nil
-  "nil でないとき、Tコードを使用できるようにisearchを拡張する。")
+  "nil でないとき、Tコードを使用できるように isearch を拡張する。
+
+次のシンボルのいずれかを指定する。
+ nil         : isearch 中にTコードを使用しない。
+ `overwrite' : Emacs 内部関数の書き換えによる実装(従来実装)を用いる。
+ `advice'    : advice による実装を用いる。
+デフォルト値は `overwrite'。nil にするには、設定ファイル ~/.tc 内で
+セットする。")
 
 (defvar tcode-use-as-default-input-method nil
   "nil でないとき、Tコードをデフォールトのinput methodにする。")

--- a/tc-setup.el
+++ b/tc-setup.el
@@ -77,7 +77,7 @@
 	   tcode-use-as-default-input-method)
       (progn
 	(require 'tc-sysdep)
-	(require tcode-isearch-type)))
+	(require tcode-isearch-overwrite-module)))
   ;; autoload
   (autoload 'tcode-use-package "tc")
   (autoload 'tcode-activate "tc")

--- a/tc-setup.el
+++ b/tc-setup.el
@@ -31,7 +31,7 @@
        (file-exists-p tcode-init-file-name)
        (progn
 	 (require 'tc-sysdep)
-	 (setq tcode-use-isearch t
+	 (setq tcode-use-isearch 'overwrite
 	       tcode-use-as-default-input-method t)
 	 (load tcode-init-file-name)))
   ;; map toggle-input-method to `C-\'

--- a/tc-setup.el
+++ b/tc-setup.el
@@ -24,6 +24,18 @@
 
 (require 'tc-pre)
 
+(defun tcode--load-isearch ()
+  "`tcode-use-isearch' の設定に応じて必要なファイルをロードする。"
+  (cond ((eq tcode-use-isearch 'overwrite)
+         (require 'tc-sysdep)
+         (require tcode-isearch-overwrite-module))
+        ((eq tcode-use-isearch 'advice)
+         (require 'tc-ishelper))
+        ((eq tcode-use-isearch nil) )  ; do nothing
+        (t
+         (lwarn 'tcode :warning "Invalid value `%s' for `tcode-use-isearch'."
+                tcode-use-isearch))))
+
 (if (featurep 'tc-setup)
     ()
   ;; load configuration file
@@ -31,8 +43,10 @@
        (file-exists-p tcode-init-file-name)
        (progn
 	 (require 'tc-sysdep)
-	 (setq tcode-use-isearch 'overwrite
-	       tcode-use-as-default-input-method t)
+	 ;; .tc を用意しているユーザーへの default 値。
+	 ;; nil に設定したい場合は、.tc でセットする必要がある。
+	 (setq tcode-use-isearch (or tcode-use-isearch 'overwrite))
+	 (setq tcode-use-as-default-input-method t)
 	 (load tcode-init-file-name)))
   ;; map toggle-input-method to `C-\'
   (if (or (memq tcode-emacs-version '(mule-1 mule-2))
@@ -73,11 +87,8 @@
 	(setq-default default-input-method tcode-default-input-method)
 	(setq default-input-method tcode-default-input-method)))
   ;; isearch
-  (if (and tcode-use-isearch
-	   tcode-use-as-default-input-method)
-      (progn
-	(require 'tc-sysdep)
-	(require tcode-isearch-overwrite-module)))
+  (when tcode-use-as-default-input-method
+    (tcode--load-isearch))
   ;; autoload
   (autoload 'tcode-use-package "tc")
   (autoload 'tcode-activate "tc")

--- a/tc.el
+++ b/tc.el
@@ -1075,7 +1075,7 @@ Emacsが起動されてから最初のtcode-modeで実行される。
       (error "`tcode-data-directory'(%s)が存在しません。"
 	     tcode-data-directory))
   (if tcode-use-isearch
-      (require tcode-isearch-type))
+      (require tcode-isearch-overwrite-module))
   (add-hook 'minibuffer-exit-hook 'tcode-exit-minibuffer)
   (when (and (fboundp 'inactivate-input-method)
 	     (fboundp 'defadvice))

--- a/tc.el
+++ b/tc.el
@@ -1074,8 +1074,7 @@ Emacsが起動されてから最初のtcode-modeで実行される。
 	   (not (file-exists-p tcode-data-directory)))
       (error "`tcode-data-directory'(%s)が存在しません。"
 	     tcode-data-directory))
-  (if tcode-use-isearch
-      (require tcode-isearch-overwrite-module))
+  (tcode--load-isearch)
   (add-hook 'minibuffer-exit-hook 'tcode-exit-minibuffer)
   (when (and (fboundp 'inactivate-input-method)
 	     (fboundp 'defadvice))

--- a/test/run.bash
+++ b/test/run.bash
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# 複数バージョンの emacs と、複数の初期設定オプションの組み合わせで、
+# tctest のバッチテストを実行する。
+#
+# 実行方法:
+#   1. tc-setup.el のあるディレクトリに cd する。(カレントディレクトリ
+#      が load-path に加えられる。)
+#   2. このスクリプトを、パス指定で実行する。通常は test/run.bash でよ
+#      い。テスト開発時など、tctest.el が別の場所にある場合は、そのディ
+#      レクトリにある run.bash を実行する。(run.bash のあるディレクト
+#      リが load-path に加えられる。)
+#   3. テスト対象の各バージョンの emacs のコマンド名を、「,」で区切っ
+#      て並べたものを、第1引数に指定する。
+#   4. 初期設定方法のキーワード(tctest-env.el 参照)を、「,」で区切って
+#      並べたものを、第2引数に指定する。
+#   5. 残りの引数は、そのまま emacs に渡される。
+#
+# 実行例:
+#  $ cd ~/tc
+#  $ test/run.bash emacs-30 isadvice --batch
+#     動作: 以下と同じ。つまり、(setq tcode-use-isearch 'advice) が設
+#           定され、ert のバッチテストが実行される。
+#     $ TCTEST_ENV=isadvice emacs-30 -L ~/tc -L ~/tc/test -l tctest.env --batch
+#
+#  $ test/run.bash emacs-30,emacs-26 isoverwrite,isadvice,isim --batch
+#     動作: 以下を順に実行するのと同じ。
+#      $ test/run.bash emacs-30 isoverwrite --batch
+#      $ test/run.bash emacs-30 isadvice    --batch
+#      $ test/run.bash emacs-30 isim        --batch
+#      $ test/run.bash emacs-26 isoverwrite --batch
+#      $ test/run.bash emacs-26 isadvice    --batch
+#      $ test/run.bash emacs-26 isim        --batch
+#
+# Windows での注意点:
+#  - バッチモードで動作する Windows 用 emacs は、ターミナルへ直接日本
+#    語文字を出力すると、終了コードが1になってしまう。原因不明。
+#    workaroundとして、出力先をファイル、または、パイプにすればよい。
+#     例:
+#       $ test/run.bash emacs-30 isadvice --batch 2>&1 | tee /tmp/out
+
+test_dir=$(dirname "$0")
+cmds=$1; shift
+keywords=$1; shift
+
+fixed_args="-L . -L "$test_dir" -l tctest-env"
+
+total=0
+for cmd in ${cmds//,/ }; do   # split by comma
+    for keyword in ${keywords//,/ }; do
+	echo ========================================
+	echo Running TCTEST_ENV=$keyword $cmd $fixed_args "$@"
+	TCTEST_ENV=$keyword $cmd $fixed_args "$@"
+	status=$?
+	echo ------ exit status: $status -----
+	total=$(( total + status ))
+    done
+done
+echo exit status total: $total
+test "$total" -eq 0

--- a/test/tctest-env.el
+++ b/test/tctest-env.el
@@ -1,0 +1,143 @@
+;;; tctest-env.el --- Setup environment for tctest. -*- lexical-binding: nil -*-
+
+;; isearch 用設定を変えながら、T-Code 用 ert テストを繰り返し実行する
+;; 際の、「.tc を書き換えて emacs 起動」の手間を減らすためのスクリプト。
+;;
+;; 環境変数 TCTEST_ENV=keyword1:keyword2:... の設定に従って T-Code の
+;; 初期設定を行なう。ert テストの手動実行、または run.bashと共に、バッ
+;; チテストの起動に用いる。
+;;
+;; 実行例: (run.bash の実行例も参照。)
+;;  $ TCTEST_ENV=isadvice emacs --batch -L ~/tc -L ~/tc/test -l tctest-env
+;;      動作 : (setq tcode-use-isearch 'advice) を設定した上でディレク
+;;             トリ ~/tc 下の tc-setup、test/tctest をロードし、ert の
+;;             テストをバッチモードで実行する。
+;;
+;;  $ TCTEST_ENV=isoverwrite emacs -Q -L ~/tc -L ~/tc/test -l tctest-env
+;;      動作 : (setq tcode-use-isearch 'overwrite) を設定した上で
+;;             tc-setup、tctest をロードする。--batch を指定していない
+;;             ので、テストのバッチ実行は行なわれない。M-x ert で手動
+;;             実行できる。(この場合、個人用設定がテストに影響しないよ
+;;             う、-Q 推奨。)
+;;
+;; 必須キーワード(どれか一つを設定する):
+;;   isnil       : tcode-use-isearch を nil        に設定する。
+;;   isoverwrite : tcode-use-isearch を 'overwrite に設定する。
+;;   isadvice    : tcode-use-isearch を 'advice    に設定する。
+;;   isim        : tcode-use-isearch を 'im        に設定する。
+;;   notc        : tc-setup をロードしない。
+;;
+;; オプションキーワード:
+;;   nobatch  : バッチテストを実行しない。(デフォルトでは、emacs を
+;;              --batch で起動するとバッチテストを自動で実行する。)
+;;   debug    : debug-on-error を t に設定する。
+;;   notctest : tctest.el をロードしない。
+;;   uim      : tcode-use-input-method を t に設定する。
+;;   nodefim  : tcode-use-as-default-input-method を nil に設定する。
+;;
+;;  FIXME: バッチモードで、単体テストを実行できるようにしたい。
+;;  --batch で起動した emacs は、対話モードと動作が異なる場合がある
+;;  (sit-for がsleep-for の動作になるなど)。テストのデバッグ用に単体実
+;;  行機能が必要。
+;;
+;;  FIXME: .tc ファイルや ~/tcode ディレクトリの初期設定機能が必要かも。
+;;  現状はユーザー任せ。tctest.el のテスト内容は、プレーンな設定を仮定
+;;  している。
+
+(defvar tcode-use-isearch)
+(defvar tcode-use-input-method)
+(defvar tcode-use-as-default-input-method)
+
+(defconst tctest-env-mandatory-keywords
+  '("isim" "isadvice" "isoverwrite" "ist" "isnil" "notc")
+  "isearch 実装の種別。TCTEST_ENV には、これらのうち一つを必ず指定する。")
+
+(defun tctest-env-chk-mandatory (keywords)
+  "必要なキーワードがセットされているかチェックする。"
+  (let ((count 0))
+    (dolist (w tctest-env-mandatory-keywords)
+      (when (member w keywords)
+	(setq count (1+ count))))
+    (when (/= count 1)
+      (error "Exactly one of %s must be specified as keyword"
+	     tctest-env-mandatory-keywords))))
+
+(defun tctest-env-msg (fmt &rest args)
+  "バッファ、またはバッチモードの場合標準エラーにメッセージを出力する。"
+  (let ((msg (apply #'format fmt args)))
+    (if noninteractive
+	(message msg) ; to stderr
+      (insert msg "\n"))))
+
+(defun tctest-env-load-tc (keywords)
+  "変数設定をした上で、tc-setup をロードする。"
+  ;; tctest-env-chk-mandatory によるチェックにより、キーワード isim,
+  ;; isadvice, isoverwrite, isnil, ist, notc は、これらのうちちょうど1
+  ;; つだけが指定されている。
+  (when (member "isim" keywords)
+    (setq tcode-use-isearch 'im))
+  (when (member "isadvice" keywords)
+    (setq tcode-use-isearch 'advice))
+  (when (member "isoverwrite" keywords)
+    (setq tcode-use-isearch 'overwrite))
+  (when (member "ist" keywords)
+    (setq tcode-use-isearch t))
+  (when (member "isnil" keywords)
+    (with-eval-after-load ".tc"
+      (setq tcode-use-isearch nil)))
+  (when (member "nodefim" keywords)
+    (with-eval-after-load ".tc"
+      (setq tcode-use-as-default-input-method nil)))
+  (when (member "uim" keywords)
+    (setq tcode-use-input-method t))
+  (unless (member "notc" keywords)
+    (require 'tc-setup))
+  (when (member "nodefim" keywords)
+    ;; batch モードで [IMON] 時に input method を聞かれるのを防ぐ。
+    (set-input-method "japanese-T-Code")))
+
+(defun tctest-env-show-exprs (exprs)
+  "リスト EXPRS の各要素を評価して値を表示する。"
+  (dolist (expr exprs)
+    (let ((val (if (symbolp expr)
+		   (if (boundp expr)
+		       (symbol-value expr)
+		     'UNDEF)
+		 (eval expr))))
+      (tctest-env-msg "%S: %S" expr val))))
+
+(defun tctest-env-run-test (keywords)
+  "ert のバッチテストを実行する。"
+  (when (and noninteractive
+	     (not (member "nobatch" keywords)))
+    ;; FIXME: quiet オプションは、実験的に付けてはみたものの、isearch
+    ;; の echo area 表示が標準エラーに大量に出力されるので、あまり意味
+    ;; はなかった。個々のテスト中で、inhibit-message t を設定する機能
+    ;; を追加する必要がある。
+    (let ((ert-quiet (member "quiet" keywords)))
+      (ert-run-tests-batch-and-exit))))
+
+(defun tctest-env-main ()
+  (let* ((keywords-packed (or (getenv "TCTEST_ENV")
+			      (error "TCTEST_ENV not specified")))
+	 (keywords (split-string keywords-packed ":")))
+    (tctest-env-chk-mandatory keywords)
+    (when (member "debug" keywords)
+      (setq debug-on-error t))
+    (tctest-env-msg "dir: %s" default-directory)
+    (tctest-env-msg "emacs-version: %s" emacs-version)
+    (tctest-env-msg "keywords: %S" keywords)
+    (tctest-env-load-tc keywords)
+    (unless (or (member "notc" keywords)
+		(member "notctest" keywords))
+      (require 'tctest))
+    (tctest-env-show-exprs '(tcode-data-directory
+			     tcode-use-isearch
+			     tcode-use-input-method
+			     tcode-use-as-default-input-method
+			     (locate-library "tc-setup")
+			     (featurep 'tc-is22)
+			     (featurep 'tc-ishelper)))
+    (tctest-env-run-test keywords)))
+
+(tctest-env-main)

--- a/test/tctest-play.el
+++ b/test/tctest-play.el
@@ -1,0 +1,448 @@
+;;; tctest-play.el --- Input method tester. -*- lexical-binding: nil -*-
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; *General purpose key-input/result tester
+
+(defvar tctest-play-default-params
+  #s(hash-table data (:timeout 2 :error-filter tctest-default-error-filter))
+  "Default values used by `tctest-play'.")
+
+(defvar tctest-play-buffer nil "Buffer where keyboard macro is executed.")
+
+(defun tctest-play (keys &rest args)
+  "Create a new buffer and execute a keyboard macro defined by (kbd KEYS).
+Then insert `<!>' at point.
+
+Markers:
+  `<TIMEOUT>' and `<ERROR:...>' indicate the point where the macro was
+  abnormally terminated.
+  `<DING>' indicates the point where the bell was rung.
+
+Return the resulting buffer contents as a string.
+
+Keyword arguments:
+  :initial STR      Initial contents of the buffer.
+  :timeout SECONDS  Stop the macro after the specified duration.
+  :buf BUFFER       Use BUFFER instead of creating a new one.
+  :no-ding t        Do not insert `<DING>'.
+  :setup-fun FUN    Call FUN before running the macro.
+  :cleanup-fun FUN  Call FUN after running the macro.
+  :no-kbd t         Pass KEYS directly to `execute-kbd-macro'
+                    without `kbd'.
+  :error-filter FUN Use FUN to convert an error object to an
+                    `<ERROR:>' string.
+  :params HASH      Pass parameters using a hash-table object.
+
+The HASH object passed as :params -- or a newly created one if
+unspecified -- is populated with other parameters and passed as the
+sole argument to both :setup-fun and :cleanup-fun."
+  (let* ((params (tctest-fill-params tctest-play-default-params args))
+	 (initial      (gethash :initial      params))
+	 (timeout      (gethash :timeout      params))
+	 (buf          (gethash :buf          params))
+	 (no-kbd       (gethash :no-kbd       params))
+	 (no-ding      (gethash :no-ding      params))
+	 (setup-fun    (gethash :setup-fun    params))
+	 (cleanup-fun  (gethash :cleanup-fun  params))
+	 (error-filter (gethash :error-filter params)))
+    (puthash :keys keys params)
+    (when (null buf)
+      (setq buf (generate-new-buffer "*play*"))
+      (puthash :buf buf params))
+    (setq tctest-play-buffer buf)
+    (pop-to-buffer buf)
+    (when initial
+      (save-excursion
+	(insert initial)))
+    (when setup-fun
+      (funcall setup-fun params))
+    (unwind-protect
+	(condition-case err
+	    (with-timeout (timeout (error "TIMEOUT"))
+	      (tctest-advice)
+	      (set-match-data '(1 1)) ; somewhere harmless
+	      (execute-kbd-macro (if no-kbd keys (kbd keys)))
+	      (insert "<!>"))
+	  (error
+	   (insert (funcall error-filter err))))
+      (tctest-unadvice no-ding)
+      (when cleanup-fun
+	(funcall cleanup-fun params)))
+    buf))
+
+(defun tctest-check (keys &rest args)
+  "Compare the result of (tctest-play KEYS ...) with :expect STR parameter.
+Return nil if they are equal.  Otherwise return the result as a string.
+Specifying :show-buf t displays the result buffer with additional info."
+  (let* ((params (tctest-fill-params nil args))
+	 (show-buf    (gethash :show-buf    params))
+	 (expect      (gethash :expect      params))
+	 (cleanup-fun (gethash :cleanup-fun params))
+	 (conf (current-window-configuration))
+	 buf result status)
+    (when (eq show-buf :defer-cleanup)
+      (puthash :cleanup-postponed cleanup-fun params)
+      (puthash :cleanup-fun nil params))
+    (setq buf (apply #'tctest-play keys args))
+    (setq result (with-current-buffer buf
+		   (buffer-string)))
+    (setq status (equal result expect))
+    (if show-buf
+	(tctest-show-status params status)
+      (kill-buffer buf)
+      (set-window-configuration conf))
+    (if status
+	nil
+      result)))
+
+(defvar tctest-ding-markers nil "List of points where (ding) is called.")
+(defun tctest-advice ()
+  "Temporarily disable features that prevent test execution."
+  (setq tctest-ding-markers nil)
+  (advice-add 'sit-for :around #'tctest-sit-for)
+  (advice-add 'ding :around #'tctest-silent-ding))
+
+(defun tctest-unadvice (no-ding)
+  "Restore disabled features and insert <DING> markers."
+  (when (not no-ding)
+    (dolist (marker tctest-ding-markers)
+      (goto-char marker)
+      (insert "<DING>")))
+  (advice-remove 'sit-for #'tctest-sit-for)
+  (advice-remove 'ding #'tctest-silent-ding))
+
+(defun tctest-sit-for (orig-fun &rest args)
+  "Replace `sit-for' with no-op when in batch mode, where `sit-for' ignores
+user inputs."
+  (if noninteractive
+      nil
+    (apply orig-fun args)))
+
+(defun tctest-silent-ding (&rest args)
+  "`ding' that do not stop keyboard macro."
+  ;; Inserting <DING> now invalidates (match-data) used by [MATCH].
+  ;; Do it later.
+  (with-current-buffer tctest-play-buffer
+    (push (copy-marker (point)) tctest-ding-markers)))
+
+(defun tctest-default-error-filter (err)
+  "Default error-filter for `tctest-play'."
+  (let ((type (nth 0 err))
+	(msg  (nth 1 err)))
+    (if (equal msg "TIMEOUT")
+	"<TIMEOUT>"
+      (format "<ERROR:%S:%s>" type msg))))
+
+(defun tctest-fill-params (default-params plist)
+  "Create a new hash-table (unless PLIST has :params HASH, in which
+case the HASH is used) and fill it with key-value pairs in PLIST and
+hash-table DEFAULT-PARAMS."
+  (let ((params (plist-get plist :params)))
+    (when (null params)
+      (setq params (make-hash-table)))
+    (when default-params
+      (maphash (lambda (k v) (puthash k (gethash k params v) params))
+	       default-params))
+    (when (= (% (length plist) 2) 1)
+      (error "Odd number of elements in KEY VALUE ... list"))
+    (while plist
+      (let* ((k (pop plist))
+	     (v (pop plist)))
+	(unless (eq k :params)
+	  (puthash k v params))))
+    params))
+
+(defvar tctest-params nil
+  "Params for `tctest-play', used by postponed cleanup-fun.")
+
+(defun tctest-show-status (params status)
+  "Append information to the result buffer of `tctest-play'."
+  (let* ((initial  (gethash :initial  params))
+	 (expect   (gethash :expect   params))
+	 (buf      (gethash :buf      params))
+	 (keys     (gethash :keys     params))
+	 (show-buf (gethash :show-buf params))
+	 (cleanup-msg (if (eq show-buf :defer-cleanup)
+			  " and call cleanup-fun" ""))
+	 status-pos)
+    (with-current-buffer buf
+      (goto-char (point-max))
+      (unless (bolp) (insert "\n"))
+      (insert "----------- expect -----------\n")
+      (insert (or expect "No :expect specified"))
+      (unless (bolp) (insert "\n"))
+      (insert "----------- status -----------\n")
+      (insert (if status "OK" "FAILURE"))
+      (setq status-pos (point))
+      (insert "        ('q' to kill buffer" cleanup-msg ")\n")
+      (insert "----------- initial -----------\n")
+      (insert (or initial "No :initial specified"))
+      (unless (bolp) (insert "\n"))
+      (insert "----------- keys -----------\n")
+      (insert keys "\n")
+      (when current-input-method
+	(toggle-input-method))
+      (tctest-q-quit-mode)
+      (setq-local tctest-params params)
+      (add-hook 'kill-buffer-hook 'tctest-on-kill-buf nil t) ; t: local
+      (goto-char status-pos))))
+
+(defun tctest-on-kill-buf ()
+  "Called when the result buffer of `tctest-play' is Killed."
+  (let ((cleanup-fun (gethash :cleanup-postponed tctest-params)))
+    (when cleanup-fun
+      (funcall cleanup-fun tctest-params))))
+
+(defvar tctest-q-quit-mode-map)
+(define-minor-mode tctest-q-quit-mode
+  "Minor mode where `q' kills buffer and window."
+  :lighter " q-quit"
+  :keymap '(("q" . tctest-quit-buffer))
+  (setq buffer-read-only t)
+  (setq minor-mode-overriding-map-alist
+	(cons (cons 'tctest-q-quit-mode tctest-q-quit-mode-map)
+	      minor-mode-overriding-map-alist)))
+
+(defun tctest-quit-buffer ()
+  "Kill the current buffer and its window."
+  (interactive)
+  (let ((buf (current-buffer)))
+    (quit-window)
+    (kill-buffer buf)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; T-Code specific features
+
+(declare-function tcode-set-key      "tc")
+(declare-function tcode-encode       "tc")
+(declare-function tcode-key-to-char  "tc")
+(defvar tcode-table)
+(defvar tcode-mode-map)
+(defvar tcode-use-postfix-bushu-as-default)
+(defvar tcode-use-prefix-mazegaki)
+
+(defvar tctest-cmp-default-params
+  #s(hash-table data (:show-buf nil))
+  "Default values used by `tctest-cmp'.")
+
+(defun tctest-cmp (keys &rest args)
+  "T-Code テスト用の設定を行なった上で、`tctest-check'を呼ぶ。
+tctest-check および tctest-play の受け取る引数に加えて、以下の
+キーワード引数を指定できる。
+  :vars ((VAR VAL)...) : テストの間だけ、変数 VAR に 値 VAL をセットする。
+  :requires (PKG...)   : (require PKG) を実行する。
+  :input-method NAME   : テストの間だけ input method を NAME に変更する。"
+  (toggle-input-method) ; load tc
+  (toggle-input-method)
+  (let* ((params (tctest-fill-params tctest-cmp-default-params args))
+	 (setup-user-fun   (gethash :setup-fun   params))
+	 (cleanup-user-fun (gethash :cleanup-fun params)))
+    (when setup-user-fun
+      (puthash :setup-user-fun   setup-user-fun   params))
+    (when cleanup-user-fun
+      (puthash :cleanup-user-fun cleanup-user-fun params))
+    (puthash :setup-fun   #'tctest-setup params)
+    (puthash :cleanup-fun #'tctest-cleanup params)
+    (tctest-check (tctest-key-filter keys) :params params)))
+
+(defvar tctest-key-abbrevs
+  '(("[UNDO]" "C-x u" nil nil)
+    ;; IME ON/OFF。テストの読みやすさのため、ON/OFF 別の記法を用意する。
+    ("[IMON]"  "C-\\" nil nil)
+    ("[IMOFF]" "C-\\" nil nil)
+    ;; isearch のマッチ範囲を[]で囲む。
+    ("[MATCH]" "C-c C-m" tctest-show-match nil)
+    ;; モードラインの input method モード部分を挿入する。
+    ("[MODE]"  "C-c C-l" tctest-show-modeline nil)
+    ("[MODE]"  "C-c C-l" tctest-show-modeline isearch-mode-map))
+  "キー列の略称の定義。(ABBREV KEY CMD KEYMAP) のリスト。
+CMD が非 nil の場合は KEYMAP のシンボルが指すキーマップ上でバインドされる。
+KEYMAP が nil の場合は tctest-mode-map が用いられる。")
+
+(defun tctest-set-abbrev-keys (params)
+  "`tctest-key-abbrevs' の設定に従ってキーバインドを行なう。"
+  (dolist (tuple tctest-key-abbrevs)
+    (let ((abbrev  (nth 0 tuple))
+	  (key     (nth 1 tuple))
+	  (cmd     (nth 2 tuple))
+	  (key-map (or (nth 3 tuple) 'tctest-mode-map)))
+      (when cmd
+	(tctest-define-key params (symbol-value key-map) (kbd key) cmd)))))
+
+;; 例:
+;;   (tctest-where 'tcode-toggle-alnum-mode)         ==> "33"
+;;   (tctest-where 'tcode-mazegaki-begin-conversion) ==> "fj"
+(defun tctest-where (cmd)
+  "コマンド CMD に割り当てられた T-Code キー列(打鍵文字列)。"
+  (let ((keys (tctest-where-iter cmd tcode-table nil)))
+    (concat (mapcar #'tcode-key-to-char keys))))
+
+;; key: 0..39 returned by (tcode-char-to-key CHAR)
+(defun tctest-where-iter (cmd table keys-so-far)
+  (cond ((eq cmd table)
+	 (reverse keys-so-far))
+	((vectorp table)
+	 (catch 'out
+	   (dotimes (i (length table))
+	     (let ((ret (tctest-where-iter cmd (aref table i)
+					   (cons i keys-so-far))))
+	       (when ret
+		 (throw 'out ret))))))))
+
+(defun tctest-bushu-cmd (post)
+  "前置(POST が nil のとき)または後置の部首変換コマンドを返す。"
+  (if (eq post tcode-use-postfix-bushu-as-default)
+      'tcode-bushu-begin-conversion
+    'tcode-bushu-begin-alternate-conversion))
+
+(defun tctest-maze-cmd (post)
+  "前置(POST が nil のとき)または後置の交ぜ書き変換コマンドを返す。"
+  (if (eq (not post) tcode-use-prefix-mazegaki)
+      'tcode-mazegaki-begin-conversion
+    'tcode-mazegaki-begin-alternate-conversion))
+
+(defun tctest-bushu-keys (post)
+  "前置(POST が nil のとき)または後置の部首変換キー列を返す。"
+  (tctest-where (tctest-bushu-cmd post)))
+
+(defun tctest-maze-keys (post)
+  "前置(POST が nil のとき)または後置の交ぜ書き変換キー列を返す。"
+  (tctest-where (tctest-maze-cmd post)))
+
+(defun tctest-tc-char-p (ch)
+  "テスト入力キー列のうち、T-Code 文字と見なす文字(厳密ではない)。
+T-Code 表逆引きにより、ASCII 文字列に変換される。"
+  (> ch 127))
+
+(defun tctest-untc (keys)
+  "文字列 KEYS のうち、T-Code 文字を ASCII 文字列に変換する。"
+  (let ((chs nil))
+    (dolist (ch (string-to-list keys))
+      (if (tctest-tc-char-p ch)
+	  (let ((key-seq (tcode-encode ch)))
+	    (when (null key-seq)
+	      (error "can't use non-tcode char in input keys"))
+	    (dolist (key key-seq)
+	      (push (tcode-key-to-char key) chs)))
+	(push ch chs)))
+    (concat (nreverse chs))))
+
+(defun tctest-expand-key-abbrevs (keys)
+  "文字列 KEYS 中の特殊キーワードを、対応するキー列に変換する。"
+  (let* ((kuten-keys   (tctest-where 'tcode-switch-variable))
+	 (2balnum-keys (tctest-where 'tcode-toggle-alnum-mode))
+	 (conv-abbrevs
+	  (list (list "[POSTBUSHU]" (tctest-bushu-keys t))
+		(list "[PREBUSHU]"  (tctest-bushu-keys nil))
+		(list "[POSTMAZE]"  (tctest-maze-keys t))
+		(list "[PREMAZE]"   (tctest-maze-keys nil))
+		;; 日本語句読点[KUTEN_J]と、ascii 句読点[KUTEN_A] は同じキー。
+		;; テストの意図がわかりやすいよう、区別して書く。
+		(list "[KUTEN_J]"   kuten-keys)
+		(list "[KUTEN_A]"   kuten-keys)
+		;; 全角英数[ALNUM_ZEN]と半角英数[ALNUM_HAN]も同じキー。
+		(list "[ALNUM_ZEN]" 2balnum-keys)
+		(list "[ALNUM_HAN]" 2balnum-keys))))
+    (dolist (pair (append tctest-key-abbrevs conv-abbrevs))
+      (let ((from (nth 0 pair))
+	    (to   (nth 1 pair)))
+	(setq to (concat " " to " "))
+	(setq keys (replace-regexp-in-string (regexp-quote from)
+					     to keys t t)))))
+  keys)
+
+(defun tctest-key-filter (keys)
+  "文字列 KEYS の中の T-Code 文字と特殊キーワードをキー列に置換する。"
+  (tctest-untc (tctest-expand-key-abbrevs keys)))
+
+(defun tctest-show-modeline ()
+  "モードラインの input method 状態表示部分(`[TC]' など)をバッファに挿入する。"
+  (interactive)
+  (insert (format "[%s]" (or current-input-method-title ""))))
+
+(defun tctest-show-match ()
+  "直前のサーチのマッチ位置を[]で囲む。"
+  (interactive)
+  (save-excursion
+    (goto-char (match-end 0))
+    (insert "]")
+    (goto-char (match-beginning 0))
+    (insert "[")))
+
+(defun tctest-set-local-vars (alist)
+  "(シンボル 値) のリストに従って、バッファローカル変数をセットする。"
+  (dolist (pair alist)
+    (let ((var (nth 0 pair))
+	  (val (nth 1 pair)))
+      (set (make-local-variable var) val))))
+
+(defvar tctest-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-q") 'tctest-quit-buffer)
+    map)
+  "`tctest-cmp'によるテストで使用するキーバインディング。")
+
+(define-derived-mode tctest-mode fundamental-mode "Tctest"
+  "`tctest-cmp'のキーバインディングを提供する major mode。")
+
+(defun tctest-setup (params)
+  "`tctest-cmp'で作られるバッファの初期設定を行なう。"
+  (let* ((vars           (gethash :vars           params))
+	 (requires       (gethash :requires       params))
+	 (input-method   (gethash :input-method   params))
+	 (setup-user-fun (gethash :setup-user-fun params)))
+    (tctest-mode) ;; これの前のsetq-localは忘れるので注意。
+    (tctest-set-abbrev-keys params)
+    (dolist (pkg requires)
+      (require pkg))
+    (when input-method
+      (puthash :bak-input-method default-input-method params)
+      (set-input-method input-method)
+      (toggle-input-method)) ; 初期状態はIMオフ。
+    (when vars
+      (tctest-set-local-vars vars))
+    (when setup-user-fun
+      (funcall setup-user-fun params))))
+
+(defun tctest-cleanup (params)
+  "`tctest-setup'で行なった設定を取り消す。"
+  (let ((bak-input-method (gethash :bak-input-method params))
+	(define-keys      (gethash :define-key       params))
+	(tcode-keys       (gethash :tcode-set-key    params))
+	(cleanup-user-fun (gethash :cleanup-user-fun params)))
+    (when cleanup-user-fun
+      (funcall cleanup-user-fun params))
+    (dolist (pair tcode-keys)
+      (apply #'tcode-set-key pair))
+    (dolist (triple define-keys)
+      (apply #'define-key triple))
+    (when bak-input-method
+      (set-input-method bak-input-method))))
+
+(defun tctest-add-to-list-param (params key val)
+  "値がリストであるような PARAMS の要素の先頭に、VAL を追加する。"
+  (let ((ls (gethash key params)))
+    (push val ls)
+    (puthash key ls params)))
+
+(defun tctest-define-key (params map key cmd)
+  "キーマップ MAP にキーバインディングを追加する。
+`tctest-cmp'によるテスト終了時にこのバインディングは解除される。"
+  (let ((old-cmd (lookup-key map key)))
+    (tctest-add-to-list-param params :define-key (list map key old-cmd))
+    (define-key map key cmd)))
+
+(defun tctest-tcode-set-key (params key cmd)
+  "`tcode-mode-map'にキーバインディングを追加する。
+`tctest-cmp'によるテスト終了時にこのバインディングは解除される。"
+  (let ((old-cmd (lookup-key tcode-mode-map key)))
+    (tctest-add-to-list-param params :tcode-set-key (list key old-cmd))
+    (tcode-set-key key cmd)))
+
+(defun tctest-bind-katakana (params)
+  "`#' でカタカナモードをオン/オフできるようにする。"
+  (tctest-set-local-vars '((tcode-katakana-mode-indicator "カ")
+			   (tcode-hiragana-mode-indicator "ひ")))
+  (tctest-tcode-set-key params "#" 'tcode-toggle-katakana-mode))
+
+(provide 'tctest-play)

--- a/test/tctest-play.el
+++ b/test/tctest-play.el
@@ -25,6 +25,7 @@ Keyword arguments:
   :timeout SECONDS  Stop the macro after the specified duration.
   :buf BUFFER       Use BUFFER instead of creating a new one.
   :no-ding t        Do not insert `<DING>'.
+  :quiet t          Stop showing messages to echo area and stderr.
   :setup-fun FUN    Call FUN before running the macro.
   :cleanup-fun FUN  Call FUN after running the macro.
   :no-kbd t         Pass KEYS directly to `execute-kbd-macro'
@@ -40,11 +41,13 @@ sole argument to both :setup-fun and :cleanup-fun."
 	 (initial      (gethash :initial      params))
 	 (timeout      (gethash :timeout      params))
 	 (buf          (gethash :buf          params))
+	 (quiet        (gethash :quiet        params))
 	 (no-kbd       (gethash :no-kbd       params))
 	 (no-ding      (gethash :no-ding      params))
 	 (setup-fun    (gethash :setup-fun    params))
 	 (cleanup-fun  (gethash :cleanup-fun  params))
-	 (error-filter (gethash :error-filter params)))
+	 (error-filter (gethash :error-filter params))
+	 (inhibit-message quiet))
     (puthash :keys keys params)
     (when (null buf)
       (setq buf (generate-new-buffer "*play*"))
@@ -225,6 +228,13 @@ hash-table DEFAULT-PARAMS."
   #s(hash-table data (:show-buf nil))
   "Default values used by `tctest-cmp'.")
 
+(defun tctest-load-tc ()
+  "tc.el がロード済みの状態にする。"
+  ;; (require 'tc) でも十分だが、テストなので念のため、ユーザーの使用
+  ;; 方法に準じた操作のみで実現する。
+  (toggle-input-method)  ; 初回の有効化で、tc.el がロードされる。
+  (toggle-input-method))
+
 (defun tctest-cmp (keys &rest args)
   "T-Code テスト用の設定を行なった上で、`tctest-check'を呼ぶ。
 tctest-check および tctest-play の受け取る引数に加えて、以下の
@@ -232,8 +242,7 @@ tctest-check および tctest-play の受け取る引数に加えて、以下の
   :vars ((VAR VAL)...) : テストの間だけ、変数 VAR に 値 VAL をセットする。
   :requires (PKG...)   : (require PKG) を実行する。
   :input-method NAME   : テストの間だけ input method を NAME に変更する。"
-  (toggle-input-method) ; load tc
-  (toggle-input-method)
+  (tctest-load-tc)  ; T-Code 表の逆引きのために必要。
   (let* ((params (tctest-fill-params tctest-cmp-default-params args))
 	 (setup-user-fun   (gethash :setup-fun   params))
 	 (cleanup-user-fun (gethash :cleanup-fun params)))

--- a/test/tctest.el
+++ b/test/tctest.el
@@ -1,0 +1,1031 @@
+;;; tctest.el --- T-Code input method tests. -*- lexical-binding: nil -*-
+
+;;  ## 実行方法:
+;;    - emacs -Q で起動する。
+;;    - (FIXME: .tc や ~/tcode/ の設定はどうする? ひとまず、できるだけ
+;;      初期状態のものを使うとする。)
+;;    - load-path や (setq tcode-use-isearch ...) など、tcode の初期設
+;;      定を行なう。toggle-input-method で、japanese-T-Code が起動する
+;;      こと。
+;;    - (require 'tc-setup)
+;;    - (require 'tctest)
+;;    - M-x ert RET t RET
+;;       * 「t」は全てのテストを実行する。詳しくは ert の info 参照。
+;;
+;;  ## 結果確認方法
+;;    - 最初の統計情報のところに unexpected と書かれていないこと。
+;;       例:  Failed 3 (1 unexpected)  ; unexpected とあるので失敗。
+;;       例:  Failed 2                 ; unexpected がないので成功。
+;;                                      (known bug のみ fail ということ。)
+;;    - 時刻表示の下のプログレスバーが赤くなることでも失敗がわかる。
+;;
+;;  ## 個別実行方法
+;;    - 次の式を評価した上で(テスト結果バッファを消さない設定)、
+;;       (puthash :show-buf t tctest-cmp-default-params)
+;;    - (tctest-cmp ...) の式を評価する。
+;;
+;;  ## テストプログラムの読み方
+;;    - ert-deftest、should-not の意味については、ert の info 参照。
+;;    - (tctest-cmp  "C-f C-f cdef"  ; このようにキーを押すと、
+;;          :initial "ab"            ; もしバッファの初期内容がこうなら、
+;;          :expect "abcdef<!>"      ; 最終的にバッファはこうなる。
+;;                                     <!> はポイントの位置。
+;;    - tctest-cmp はテスト成功時 nil を返すので、should-not と組み合
+;;      わせる。失敗時は最終バッファ内容を返す。これが失敗リストに
+;;      value: として表示される。
+;;
+;;  ## tctest-cmp 第1引数のキー入力文字列の自動変換
+;;    - キー入力文字列には、kbd 関数の引数と同じ記法を用いる(C-x RET
+;;      SPC など)。
+;;    - 直接入力可能な日本語文字は、キー列を直接書く代わりに、日本語文
+;;      字をそのまま書くことができる(テストを読みやすくするため、また、
+;;      qwerty/dvorak の設定に依存しないテストコードにするため)。
+;;      tctest-cmp 内部で T-Code 表を使って ASCII キー列に変換したもの
+;;      が入力として用いられる(例: "あい" はqwerty 環境では "yfhd" が
+;;      入力キー列となる)。
+;;    - 以下のキーワードは、対応するキー列に変換される。
+;;       [IMON]  : C-\ (toggle-input-method)
+;;       [IMOFF] : 同上 (テストの意味がわかりやすいよう区別して書く。)
+;;       [UNDO]  : C-x u (undo)
+;;       [PREMAZE]   : 前置交ぜ書き変換
+;;       [POSTMAZE]  : 後置交ぜ書き変換
+;;       [PREBUSHU]  : 前置部首合成変換
+;;       [POSTBUSHU] : 後置部首合成変換
+;;       [ALNUM_ZEN] : 全角英数/半角英数切り換え
+;;       [ALNUM_HAN] : 同上
+;;       [KUTEN_J]   : 日本語句読点/ASCII句読点切り換え
+;;       [KUTEN_A]   : 同上
+;;    - 以下のキーワードは、特殊な関数を呼び出すキー列に変換される。
+;;       [MATCH]     : isearch のマッチ範囲を[]で囲む。
+;;       [MODE]      : モードラインの input method 状態表示部分を挿入する。
+;;
+;;  ## カタカナモードについて
+;;    - TUT-Code 用の機能であるカタカナモードをテストするために、
+;;      tctest-bind-katakana という関数が用意してある。これを
+;;      tctest-cmp の引数 :setup-fun を使って呼び出すことで、テストの
+;;      間だけ「#」がカタカナモード切り換えキーとなる。また、モードラ
+;;      インの表示が [TC] から、[TCひ][TCカ] のようにカタカナモードの
+;;      状態を表示するように切り換わる。
+
+(require 'ert)
+(require 'tctest-play)
+
+(defvar tcode-use-isearch)
+(defvar tcode-use-input-method)
+(declare-function tcode-set-key      "tc")
+
+
+;; 個別実行用の設定 (テスト結果バッファを消さない)
+;;   (puthash :show-buf t tctest-cmp-default-params)
+
+;;; *テスト環境の判別関数
+
+(defun tctest-is-non-im ()
+  "`im' 以外の isearch 実装を使っている。"
+  (memq tcode-use-isearch '(overwrite advice)))
+
+;;; *Test items
+
+;;;
+;;; *サンプルコード
+;;;
+
+(ert-deftest tctest-sample ()
+  "テストの書き方の例。"
+  (should-not (tctest-cmp "abcd" ; 入力キー列
+    :initial "EFGH" ; バッファの初期内容
+    :expect "abcd<!>EFGH" ; 最終バッファ内容。<!>は最終ポイント位置
+    )))
+
+(ert-deftest tctest-sample-keyword ()
+  "テストの書き方の例。特に入力キー列の特殊キーワードについて。"
+  ;; kbd 関数の受け取るキー表記法に加えて、いくつかのキーワードが使える。
+  ;; [IMON]  : C-\ (toggle-input-method)
+  ;; [IMOFF] : 同上 (テストの意味がわかりやすいよう区別して書く。)
+  ;; 日本語文字は、T-Code 表を使って ASCII キー列に戻したものが使われる。
+  ;; その他のキーワード:
+  ;;   [POSTBUSHU] [PREBUSHU] [POSTMAZE] [PREMAZE] : 部首変換/交ぜ書き変換
+  ;;   [ALNUM_ZEN] [ALNUM_HAN] : 全角英数/半角英数切り換え
+  ;;   [KUTEN_J] [KUTEN_A]     : 日本語句読点/ASCII句読点切り換え
+  (should-not (tctest-cmp "ab SPC cd-gh RET ij C-p M-f [IMON] あいう [IMOFF] ef"
+    :expect "ab cdあいうef<!>-gh\nij")))
+
+(ert-deftest tctest-sample-ding ()
+  "テストの書き方の例。(ding)の鳴った場所に<DING>が書かれる。"
+  ;; 実際は(ding)は鳴らない設定。keyboard macro を止めてしまうので。
+  (should-not (tctest-cmp "[IMON] あ m8 い m8 う" ; m8 は文字割り当ての無い組
+    :expect "あ<DING>い<DING>う<!>")))
+
+(ert-deftest tctest-sample-match ()
+  "特殊キーワード[MATCH]の例。"
+  ;; [MATCH] : 直前のサーチのマッチ範囲を[]で囲むコマンド
+  (should-not (tctest-cmp "C-s cde RET [MATCH]"
+    :initial "... abcdefg"
+    :expect "... ab[cde<!>]fg")))
+
+(ert-deftest tctest-sample-ding-in-search ()
+  "サーチ失敗の<DING>の例。実装の都合でマッチ開始場所に置かれるので注意。"
+  ;; <DING>のふるまいがややこしい場合は、:no-ding t を指定する方がよいかも。
+  (should-not (tctest-cmp "C-s abce [MATCH]"
+    :initial "... a ab abc abcd"
+    :expect "... a ab <DING>[abc<!>] abcd")))
+
+;;;
+;;; *基本機能
+;;;
+
+(ert-deftest tctest-prefix-maze ()
+  "前置交ぜ書き変換ができる。"
+  (should-not (tctest-cmp "[IMON] [PREMAZE] か手 SPC"
+    :expect "歌手<!>")))
+
+(ert-deftest tctest-prefix-bushu ()
+  "前置部首変換ができる。"
+  (should-not (tctest-cmp "[IMON] [PREBUSHU] 糸会"
+    :expect "絵<!>")))
+
+(ert-deftest tctest-prefix-bushu-nest-l ()
+  "多段の前置部首変換ができる。(左結合型)"
+  (should-not (tctest-cmp "[IMON] [PREBUSHU] [PREBUSHU] イヒサ"
+    :expect "花<!>")))
+
+(ert-deftest tctest-prefix-bushu-nest-r ()
+  "多段の前置部首変換ができる。(右結合型)"
+  (should-not (tctest-cmp "[IMON] [PREBUSHU] サ [PREBUSHU] イヒ"
+    :expect "花<!>")))
+
+(ert-deftest tctest-postfix-maze ()
+  "後置交ぜ書き変換ができる。"
+  (should-not (tctest-cmp "[IMON] か手 [POSTMAZE] RET"
+    :expect "歌手<!>")))
+
+(ert-deftest tctest-postfix-bushu ()
+  "後置部首変換ができる。"
+  (should-not (tctest-cmp "[IMON] 糸会 [POSTBUSHU]画"
+    :expect "絵画<!>")))
+
+(ert-deftest tctest-alnum2b ()
+  "全角英数モードが使える。"
+  (should-not (tctest-cmp
+	       "[IMON] A b SPC [ALNUM_ZEN] A b SPC [ALNUM_HAN] A b SPC"
+    :expect "AbＡｂAb<!>")))
+
+(ert-deftest tctest-katakana ()
+  "カタカナモードが使える。"
+  (should-not (tctest-cmp "[IMON] あい # うえ # おか"
+    :expect "あいウエおか<!>"
+    :setup-fun #'tctest-bind-katakana)))
+
+(ert-deftest tctest-kuten ()
+  "句読点を変更できる。"
+  (should-not (tctest-cmp "[IMON] 。、 [KUTEN_A] 。、 [KUTEN_J] 。、"
+    :expect "。、. , 。、<!>")))
+
+(ert-deftest tctest-katakana-in-prefix-maze ()
+  "前置交ぜ書き変換中にカタカナモードに変更できる。"
+  (should-not (tctest-cmp "[IMON] あ [PREMAZE] # え # SPC い"
+    :expect "あヱい<!>"
+    :setup-fun #'tctest-bind-katakana)))
+
+(ert-deftest tctest-katakana-in-prefix-bushu ()
+  "前置部首変換中にカタカナモードに変更できる。"
+  (should-not (tctest-cmp "[IMON] あ [PREBUSHU] # い # い"
+    :expect "あ似<!>"
+    :setup-fun #'tctest-bind-katakana)))
+
+(ert-deftest tctest-kuten-in-prefix-bushu ()
+  "前置部首変換中に句点を変更できる。"
+  (should-not (tctest-cmp "[IMON] [KUTEN_A] 、 [PREBUSHU] 大 [KUTEN_J] 、"
+    :expect ", 犬<!>")))
+
+;;;
+;;; *tcode-isearch-start-state
+;;;
+(ert-deftest tctest-isearch-start-nil-off ()
+  "tcode-isearch-start-state nil、IM off で isearch 開始時 IM off"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "am C-s ma [IMON] 人 [MATCH]"
+    :initial "...人人..ma人..人ma..mama"
+    :expect  "am...人人..[ma人<!>]..人ma..mama"
+    :vars '((tcode-isearch-start-state nil)))))
+
+(ert-deftest tctest-isearch-start-nil-on ()
+  "tcode-isearch-start-state nil、IM on で isearch 開始時 IM on"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] 色 C-s 人 [IMOFF] ma [MATCH]"
+    :initial "...人人..ma人..人ma..mama"
+    :expect "色...人人..ma人..[人ma<!>]..mama"
+    :vars '((tcode-isearch-start-state nil)))))
+
+(ert-deftest tctest-isearch-start-0-off ()
+  "tcode-isearch-start-state 0、IM off で isearch 開始時 IM off"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "am C-s ma [IMON] 人 [MATCH]"
+    :initial "...人人..ma人..人ma..mama"
+    :expect "am...人人..[ma人<!>]..人ma..mama"
+    :vars '((tcode-isearch-start-state 0)))))
+
+(ert-deftest tctest-isearch-start-0-on ()
+  "tcode-isearch-start-state 0、IM on で isearch 開始時 IM off"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] 色 C-s ma [IMON] 人 [MATCH]"
+    :initial "...人人..ma人..人ma..mama"
+    :expect "色...人人..[ma人<!>]..人ma..mama"
+    :vars '((tcode-isearch-start-state 0)))))
+
+(ert-deftest tctest-isearch-start-1-off ()
+  "tcode-isearch-start-state 1、IM off で isearch 開始時 IM on"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "am C-s 人 [IMOFF] ma [MATCH]"
+    :initial "...人人..ma人..人ma..mama"
+    :expect "am...人人..ma人..[人ma<!>]..mama"
+    :vars '((tcode-isearch-start-state 1)))))
+
+(ert-deftest tctest-isearch-start-1-on ()
+  "tcode-isearch-start-state 1、IM on で isearch 開始時 IM on"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] 色 C-s 人 [IMOFF] ma [MATCH]"
+    :initial "...人人..ma人..人ma..mama"
+    :expect "色...人人..ma人..[人ma<!>]..mama"
+    :vars '((tcode-isearch-start-state 1)))))
+
+;;;
+;;; *isearch 中の prefix argument
+;;;
+(ert-deftest tctest-isearch-prefix-ascii ()
+  "isearch 中に prefix arg で ascii 文字を複数入力できる。"
+  ;; 既知の問題。
+  ;; https://github.com/kanchoku/tc/pull/30#discussion_r2602138439
+  :expected-result (if (eq tcode-use-isearch 'overwrite) :failed :passed)
+  (should-not (tctest-cmp "C-s C-u a [MATCH]"
+    :initial "...a...aaaa"
+    :expect  "...a...[aaaa<!>]")))
+
+(ert-deftest tctest-isearch-prefix-tc-char ()
+  "isearch 中に prefix arg で T-Code 文字を複数入力できる。"
+  ;; 既知の問題。
+  ;; https://github.com/kanchoku/tc/pull/30#discussion_r2602138439
+  :expected-result (if (memq tcode-use-isearch '(advice overwrite)) :failed
+		     :passed)
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s C-u あ [MATCH]"
+    :initial "...あ...ああああ"
+    :expect  "...あ...[ああああ<!>]")))
+
+;; 「。」は tcode--input-method-for-isearch の中で通常文字とは異なる
+;; 経路を通るので、別テストとしてある。
+(ert-deftest tctest-isearch-prefix-tc-str ()
+  "isearch 中に prefix arg で句点を複数入力できる。"
+  ;; 既知の問題。
+  ;; https://github.com/kanchoku/tc/pull/30#discussion_r2602138439
+  :expected-result (if (memq tcode-use-isearch '(advice overwrite)) :failed
+		     :passed)
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s C-u 。 [MATCH]"
+    :initial "...。...。。。。"
+    :expect  "...。...[。。。。<!>]")))
+
+;;;
+;;; *isearch 中の部首/交ぜ書き変換
+;;;
+
+(ert-deftest tctest-prefix-bushu-in-isearch ()
+  "isearch 中に前置部首変換ができる。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s [PREBUSHU] イ反 [MATCH]"
+    :initial "... イ反仮"
+    :expect "... イ反[仮<!>]")))
+
+(ert-deftest tctest-prefix-bushu-in-isearch-nest-l ()
+  "isearch 中に多段の前置部首変換ができる。(左結合型)"
+  ;; 非 im 実装では、合成途中でマッチが試みられて ding が発生するので回避。
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s [PREBUSHU] [PREBUSHU] イヒサ [MATCH]"
+    :initial "... イヒサ花"
+    :expect "... イヒサ[花<!>]" :no-ding (tctest-is-non-im))))
+
+(ert-deftest tctest-prefix-bushu-in-isearch-nest-r ()
+  "isearch 中に多段の前置部首変換ができる。(右結合型)"
+  ;; 非 im 実装では一段目で確定してしまう。
+  ;; 既知の問題: https://github.com/kanchoku/tc/issues/41
+  :expected-result (if (eq tcode-use-isearch 'im) :passed :failed)
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s [PREBUSHU] サ [PREBUSHU] イヒ [MATCH]"
+    :initial "... サイヒ花"
+    :expect "... サイヒ[花<!>]")))
+
+(ert-deftest tctest-prefix-maze-in-isearch ()
+  "isearch 中に前置交ぜ書き変換ができる。"
+  ;; 非 im 実装では確定後、minibufferを出るための RET が必要。次テストにて。
+  (skip-unless (eq tcode-use-isearch 'im))
+  (should-not (tctest-cmp "[IMON] C-s [PREMAZE] か手 SPC [MATCH]"
+    :initial "...か手歌手"
+    :expect "...か手[歌手<!>]")))
+
+(ert-deftest tctest-prefix-maze-in-isearch-non-im ()
+  "isearch 中に前置交ぜ書き変換ができる。非 'im 用。"
+  ;; 非 im 実装では確定後、minibufferを出るための RET が必要。
+  (skip-unless (tctest-is-non-im))
+  (should-not (tctest-cmp "[IMON] C-s [PREMAZE] か手 SPC RET [MATCH]"
+    :initial "...か手歌手"
+    :expect "...か手[歌手<!>]")))
+
+(ert-deftest tctest-postfix-bushu-in-isearch ()
+  "isearch 中に後置部首変換ができる(変換前にマッチしないケース)。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s 糸会 [POSTBUSHU] [MATCH]"
+    :initial "...絵画"
+    :expect "<DING>...[絵<!>]画")))
+
+(ert-deftest tctest-postfix-bushu-in-isearch-match-before ()
+  "isearch 中に後置部首変換ができる(変換前に行き過ぎるケース)。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s 糸会 [POSTBUSHU] [MATCH]"
+    :initial "...絵画 糸会"
+    :expect "...[絵<!>]画 糸会")))
+
+(ert-deftest tctest-postfix-maze-in-isearch ()
+  "isearch 中に後置交ぜ書き変換ができる(変換前にマッチしないケース)。"
+  ;; 非 im 実装では確定後、minibufferを出るための RET が必要。次テストにて。
+  (skip-unless (eq tcode-use-isearch 'im))
+  (should-not (tctest-cmp "[IMON] C-s か手 [POSTMAZE] RET [MATCH]"
+    :initial "...歌手"
+    :expect "<DING>...[歌手<!>]")))
+
+(ert-deftest tctest-postfix-maze-in-isearch-non-im ()
+  "isearch 中に後置交ぜ書き変換ができる(変換前にマッチしないケース)。非 im 用。"
+  ;; 非 im 実装では確定後、minibufferを出るための RET が必要。
+  (skip-unless (tctest-is-non-im))
+  (should-not (tctest-cmp "[IMON] C-s か手 [POSTMAZE] RET RET [MATCH]"
+    :initial "...歌手"
+    :expect "<DING>...[歌手<!>]")))
+
+(ert-deftest tctest-postfix-maze-in-isearch-match-before ()
+  "isearch 中に後置交ぜ書き変換ができる(変換前に行き過ぎるケース)。"
+  ;; 非 im 実装では確定後、minibufferを出るための RET が必要。次テストにて。
+  (skip-unless (eq tcode-use-isearch 'im))
+  (should-not (tctest-cmp "[IMON] C-s か手 [POSTMAZE] RET [MATCH]"
+    :initial "...歌手 か手"
+    :expect "...[歌手<!>] か手")))
+
+(ert-deftest tctest-postfix-maze-in-isearch-match-before-non-im ()
+  "isearch 中に後置交ぜ書き変換ができる(変換前に行き過ぎるケース)。非 im 用。"
+  ;; 非 im 実装では確定後、minibufferを出るための RET が必要。
+  (skip-unless (tctest-is-non-im))
+  (should-not (tctest-cmp "[IMON] C-s か手 [POSTMAZE] RET RET [MATCH]"
+    :initial "...歌手 か手"
+    :expect "...[歌手<!>] か手")))
+
+(ert-deftest tctest-delete-postfix-maze-in-isearch ()
+  "isearch 中の後置交ぜ書き変換結果を1文字だけ削除できる。"
+  ;; 非 im 実装では変換後も minibuffer にいるので問題にならない。
+  (skip-unless (eq tcode-use-isearch 'im))
+  (should-not (tctest-cmp "[IMON] C-s ななめ [POSTMAZE] RET DEL 陽 [MATCH]"
+    :initial "...斜陽...斜め"
+    :expect "<DING>...[斜陽<!>]...斜め")))
+
+(ert-deftest tctest-delete-prefix-maze-in-isearch ()
+  "isearch 中の前置交ぜ書き変換結果を1文字だけ削除できる。"
+  ;; 非 im 実装では変換後も minibuffer にいるので問題にならない。
+  (skip-unless (eq tcode-use-isearch 'im))
+  (should-not (tctest-cmp "[IMON] C-s [PREMAZE] ななめ SPC DEL 陽 [MATCH]"
+    :initial "...斜陽...斜め"
+    :expect "...[斜陽<!>]...斜め")))
+
+;;;
+;;; *isearch での各種入力モード
+;;;
+
+(ert-deftest tctest-isearch-alnum2b ()
+  "全角英数モードで isearch が使える。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] [ALNUM_ZEN] C-s ABC [MATCH] [ALNUM_HAN]"
+    :initial "...ABCＡＢＣ"
+    :expect "...ABC[ＡＢＣ<!>]")))
+
+(ert-deftest tctest-isearch-switch-alnum2b ()
+  "全角英数モードを isearch 中に切り換えられる。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s AB [ALNUM_ZEN] CD [ALNUM_HAN] EF [MATCH]"
+    :initial "...ABCDEF ABＣＤEF"
+    :expect  "...ABCDEF [ABＣＤEF<!>]")))
+
+(ert-deftest tctest-isearch-katakana ()
+  "カタカナモードで isearch が使える。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] # C-s あいう [MATCH] #"
+    :initial "...あいうアイウ"
+    :expect "...あいう[アイウ<!>]"
+    :setup-fun #'tctest-bind-katakana)))
+
+(ert-deftest tctest-switch-katakana ()
+  "カタカナモードを isearch 中に切り換えられる。"
+  ;; 非 im 実装では isearch 中に1文字コマンドの起動はできない。
+  ;; 既知の問題: https://github.com/kanchoku/tc/issues/41
+  :expected-result (if (eq tcode-use-isearch 'im) :passed :failed)
+  (should-not (tctest-cmp "[IMON] C-s あい # うえ # おか [MATCH] #"
+    :initial "...あいうえおか..あいウエおか"
+    :expect  "...あいうえおか..[あいウエおか<!>]"
+    :setup-fun #'tctest-bind-katakana)))
+
+(ert-deftest tctest-isearch-kuten_J ()
+  "isearch 中に 日本語句読点が入力できる。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s 。、[MATCH]"
+    :initial "...。、. , "
+    :expect "...[。、<!>]. , ")))
+
+(ert-deftest tctest-isearch-kuten_A ()
+  "isearch 中に ASCII 句読点が入力できる。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] [KUTEN_A] C-s 。、[MATCH] [KUTEN_J]"
+    :initial "...。、. , "
+    :expect "...。、[. , <!>]")))
+
+(ert-deftest tctest-isearch-switch-kuten ()
+  "句読点の種類を isearch 中に切り換えられる。"
+  ;; 非 im 実装では、句読点切り換えを実装していない
+  ;; (tcode-isearch-special-function-alist に入っていない。)
+  ;; 既知の問題: https://github.com/kanchoku/tc/issues/41
+  :expected-result (if (eq tcode-use-isearch 'im) :passed :failed)
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s 。、[KUTEN_A]。、[KUTEN_J]。、[MATCH]"
+    :initial "...|. , . , . , |。、. , 。、|。、。、。、"
+    :expect  "...|. , . , . , |[。、. , 。、<!>]|。、。、。、")))
+
+(ert-deftest tctest-katakana-in-isearch-prefix-maze ()
+  "isearch 中の前置交ぜ書き変換中にカタカナモードに変更できる。"
+  ;; 非 im 実装では確定後、minibufferを出るための RET が必要。次テストにて。
+  (skip-unless (eq tcode-use-isearch 'im))
+  (should-not (tctest-cmp "[IMON] C-s あ [PREMAZE] # え # SPC い [MATCH]"
+    :initial "...あえい..あヱい"
+    :expect  "...あえい..[あヱい<!>]"
+    :setup-fun #'tctest-bind-katakana)))
+
+(ert-deftest tctest-katakana-in-isearch-prefix-maze-non-im ()
+  "isearch 中の前置交ぜ書き変換中にカタカナモードに変更できる。非 im 用"
+  ;; 非 im 実装では確定後、minibufferを出るための RET が必要。
+  (skip-unless (tctest-is-non-im))
+  (should-not (tctest-cmp "[IMON] C-s あ [PREMAZE] # え # SPC RET い [MATCH]"
+    :initial "...あえい..あヱい"
+    :expect  "...あえい..[あヱい<!>]"
+    :setup-fun #'tctest-bind-katakana)))
+
+(ert-deftest tctest-katakana-in-isearch-prefix-bushu ()
+  "isearch 中の前置部首変換中にカタカナモードに変更できる。"
+  ;; im でのみ実装。
+  ;; 既知の問題: https://github.com/kanchoku/tc/issues/41
+  :expected-result (if (eq tcode-use-isearch 'im) :passed :failed)
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s あ [PREBUSHU] # い # い [MATCH]"
+    :initial "...あ似"
+    :expect "...[あ似<!>]"
+    :setup-fun #'tctest-bind-katakana)))
+
+(ert-deftest tctest-kuten-in-isearch-prefix-bushu ()
+  "isearch 中の前置部首変換中に句点を変更できる。"
+  ;; im でのみ実装。
+  ;; 既知の問題: https://github.com/kanchoku/tc/issues/41
+  :expected-result (if (eq tcode-use-isearch 'im) :passed :failed)
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp
+	       "[IMON] C-s [KUTEN_A] 、 [PREBUSHU] 大 [KUTEN_J] 、 [MATCH]"
+    :initial "..., 犬"
+    :expect "...[, 犬<!>]")))
+
+;;;
+;;; *モード表示
+;;;
+
+(ert-deftest tctest-start-mode ()
+  "テスト開始のモード表示は[]。" ; 初回 C-\ するまでは空。
+  (should-not (tctest-cmp "[MODE]"
+    :expect "[]<!>")))
+
+(ert-deftest tctest-im-mode ()
+  "[IMON][IMOFF] で [TC] 表示が切り換わる。"
+  (should-not (tctest-cmp "[IMON] [MODE] 人 [IMOFF] [MODE] ma"
+    :expect "[TC]人[--]ma<!>")))
+
+(ert-deftest tctest-alnum-mode ()
+  "[ALNUM_ZEN][ALNUM_HAN] で [Ｔ］表示が切り換わる。"
+  (should-not (tctest-cmp
+	       "[IMON] [MODE] A [ALNUM_ZEN] [MODE] A [ALNUM_HAN] [MODE] A"
+    :expect "[TC]A[Ｔ]Ａ[TC]A<!>")))
+
+(ert-deftest tctest-katakana-mode ()
+  "カタカナモードの表示が切り換わる。"
+  (should-not (tctest-cmp
+	       "[IMON] [MODE] あ # [MODE] あ # [MODE] あ"
+    :expect "[TCひ]あ[TCカ]ア[TCひ]あ<!>"
+    :setup-fun #'tctest-bind-katakana)))
+
+
+;;;
+;;; *tcode-isearch-start-stateのモード表示
+;;;
+(ert-deftest tctest-isearch-start-nil-off-mode ()
+  "t-i-s-s nil、IM off で isearch 開始時、モード表示 []"
+  (should-not (tctest-cmp "[MODE] C-s [MODE] ma [MATCH]"
+    :initial "...人.ma"
+    :expect  "[][]...人.[ma<!>]"
+    :vars '((tcode-isearch-start-state nil)))))
+
+(ert-deftest tctest-isearch-start-nil-on-mode ()
+  "t-i-s-s nil、IM on で isearch 開始時、モード表示 [TC]"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] [MODE] C-s [MODE] 人 [MATCH]"
+    :initial "...人.ma"
+    :expect  "[TC][TC]...[人<!>].ma"
+    :vars '((tcode-isearch-start-state nil)))))
+
+(ert-deftest tctest-isearch-start-0-off-mode ()
+  "t-i-s-s 0、IM off で isearch 開始時、モード表示 []"
+  (should-not (tctest-cmp "[MODE] C-s [MODE] ma [MATCH]"
+    :initial "...人.ma"
+    :expect  "[][]...人.[ma<!>]"
+    :vars '((tcode-isearch-start-state 0)))))
+
+(ert-deftest tctest-isearch-start-0-on-mode ()
+  "t-i-s-s 0、IM on で isearch 開始時、モード表示 [--]"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] [MODE] C-s [MODE] ma [MATCH]"
+    :initial "...人.ma"
+    :expect  "[TC][--]...人.[ma<!>]"
+    :vars '((tcode-isearch-start-state 0)))))
+
+(ert-deftest tctest-isearch-start-1-off-mode ()
+  "t-i-s-s 1、IM off で isearch 開始時、モード表示 [TC]"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[MODE] C-s [MODE] 人 [MATCH]"
+    :initial "...人.ma"
+    :expect  "[][TC]...[人<!>].ma"
+    :vars '((tcode-isearch-start-state 1)))))
+
+(ert-deftest tctest-isearch-start-1-on-mode ()
+  "t-i-s-s 1、IM on で isearch 開始時、モード表示 [TC]"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] [MODE] C-s [MODE] 人 [MATCH]"
+    :initial "...人.ma"
+    :expect  "[TC][TC]...[人<!>].ma"
+    :vars '((tcode-isearch-start-state 1)))))
+
+;;;
+;;; *line-fold search
+;;;
+
+(ert-deftest tctest-line-fold-search ()
+  "isearch時、日本語文字間のスペース、改行は無視される。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s 長い段落の全体 [MATCH]"
+    :initial "   長い\n   段落の   全体"
+    :expect "[   長い\n   段落の   全体<!>]"
+    :vars '((tcode-isearch-enable-line-fold-search t)))))
+
+(ert-deftest tctest-no-line-fold-search ()
+  "tcode-isearch-enable-line-fold-search が nil のとき、
+日本語文字間のスペース、改行は無視されない。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s 長い段落の全体 [MATCH]"
+    :initial "   長い\n   段落の   全体"
+    :expect "   <DING>[長い<!>]\n   段落の   全体"
+    :vars '((tcode-isearch-enable-line-fold-search nil)))))
+
+(ert-deftest tctest-line-fold-search-ignore-regexp ()
+  "tcode-isearch-ignore-regexp の設定で、スペース以外のものを無視できる。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s コメント中の長い段落 [MATCH]"
+    :initial ";;   コメント中の\n;;   長い段落"
+    :expect  "[;;   コメント中の\n;;   長い段落<!>]"
+    :vars '((tcode-isearch-ignore-regexp "[\n \t;]*")))))
+
+(ert-deftest tctest-line-fold-search-default-ignore-regexp ()
+  "前テスト(ignore-regexp)の設定が常に有効でないことの確認。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-s コメント中の長い段落"
+    :initial ";;   コメント中の\n;;   長い段落"
+    :expect  ";;<DING>   コメント中の<!>\n;;   長い段落")))
+
+;;;
+;;; *isearch 中の特殊な状況
+;;;
+
+(ert-deftest tctest-command-in-isearch ()
+  "isearch 中の tcode-mode-map のコマンドは通常入力になる。
+非 im 実装のみ。)"
+  (skip-unless (tctest-is-non-im))
+  (should-not (tctest-cmp "[IMON] C-s あ ! [MATCH]"
+    :initial "...あい...あ!"
+    :expect  "...あい...[あ!<!>]")))
+
+(ert-deftest tctest-minibuf-error-in-isearch ()
+  "isearch 中に input method 内でエラーがあっても復帰できる。"
+  ;; im 実装の開発中に直した問題。「|」で辞書登録コマンド
+  ;; (tcode-mazegaki-make-entry-and-finish) が起動し、minibuffer 使用
+  ;; がinput method と競合するのでエラーが発生する。問題修正前は
+  ;; minibuffer 内のエラーとなり、RET 待ちが発生して timeout となる。
+  ;; 非 im 系の実装では isearch 中に1文字コマンドは起動しないので skip。
+  (skip-unless tcode-use-input-method)
+  (should-not (tctest-cmp "[IMON] C-s あ | い"
+    :initial "...あいう"
+    :expect  "...あ<DING>い<!>う")))
+
+;;;
+;;; *emacs 本体の isearch 機能
+;;;
+
+(ert-deftest tctest-char-fold-search ()
+  "char-fold search が動作する。"
+  (should-not (tctest-cmp "C-s M-s ' mobius SPC cafe"
+    :initial "...möbius café"
+    :expect  "...möbius café<!>")))
+
+(ert-deftest tctest-word-search ()
+  "word-search が動作する。"
+  (should-not (tctest-cmp "M-s w ice SPC cream [MATCH]"
+    :initial "...rice-cream ice-cream"
+    :expect  "...rice-cream [ice-cream<!>]")))
+
+(ert-deftest tctest-symbol-search ()
+  "symbol-search が動作する。"
+  (should-not (tctest-cmp "M-s _ let [MATCH]"
+    :initial "...seq-let let"
+    :expect  "...seq-let [let<!>]")))
+
+(ert-deftest tctest-lax-whitespace ()
+  "isearch時、英単語間の空白数の違いは無視される。"
+  ;; overwrite 実装で動作しないことは、既知の問題。
+  ;; https://github.com/kanchoku/tc/issues/25
+  :expected-result (if (eq tcode-use-isearch 'overwrite) :failed :passed)
+  (should-not (tctest-cmp "C-s a SPC b [MATCH]"
+    :initial "...a     b"
+    :expect "...[a     b<!>]"
+    :vars '((isearch-lax-whitespace t)))))
+
+(ert-deftest tctest-no-lax-whitespace ()
+  "isearch-lax-whitespace が nil のとき、空白数の違いは無視されない。"
+  (should-not (tctest-cmp "C-s a SPC b [MATCH]"
+    :initial "...a     b"
+    :expect  "...<DING>[a <!>]    b"
+    :vars '((isearch-lax-whitespace nil)))))
+
+(ert-deftest tctest-isearch-forward-regexp ()
+  "C-M-s で正規表現サーチになる。(line-fold search に上書きされない。)"
+  (should-not (tctest-cmp "C-M-s [a] [MATCH]"
+    :initial "...a...[a]"
+    :expect  "...[a<!>]...[a]" ; 分かりにくいが、文字セット[a] が a にマッチ。
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-isearch-forward-regexp-with-arg ()
+  "C-u C-M-s で通常サーチとなり、line-fold search が有効になる。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-u C-M-s 単語 [MATCH]"
+    :initial "...英単\n   語...単語"
+    :expect  "...英[単\n   語<!>]...単語"
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-isearch-backward-regexp ()
+  "C-M-r で正規表現サーチになる。(line-fold search に上書きされない。)"
+  (should-not (tctest-cmp "C-e C-M-r [a] [MATCH]"
+    :initial "...[a]...a..."
+    :expect  "...[a]...<!>[a]..."
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-isearch-backward-regexp-with-arg ()
+  "C-u C-M-r で通常サーチとなり、line-fold search が有効になる。"
+  ;; 既知の問題: overwrite 実装では、後ろ向きの line-fold search の挙
+  ;; 動がおかしい。https://github.com/kanchoku/tc/issues/31
+  :expected-result (if (eq tcode-use-isearch 'overwrite) :failed :passed)
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] M-> C-u C-M-r 単語 [MATCH]"
+    :initial "...単語...英単\n   語..."
+    :expect  "...単語...英<!>[単\n   語]..."
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-isearch-forward-with-arg ()
+  "C-u C-s で正規表現サーチになる。(line-fold search に上書きされない。)"
+  (should-not (tctest-cmp "C-u C-s [a] [MATCH]"
+    :initial "...a...[a]"
+    :expect  "...[a<!>]...[a]" ; 分かりにくいが、文字セット[a] が a にマッチ。
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-isearch-backward ()
+  "C-r で、line-fold search が有効になる。"
+  ;; 既知の問題: overwrite 実装では、後ろ向きの line-fold search の挙
+  ;; 動がおかしい。https://github.com/kanchoku/tc/issues/31
+  :expected-result (if (eq tcode-use-isearch 'overwrite) :failed :passed)
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] M-> C-r 単語 [MATCH]"
+    :initial "...単語...英単\n   語..."
+    :expect  "...単語...英<!>[単\n   語]..."
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-isearch-backward-with-arg ()
+  "C-u C-r で正規表現サーチになる。(line-fold search に上書きされない。)"
+  (should-not (tctest-cmp "C-e C-u C-r [a] [MATCH]"
+    :initial "...[a]...a..."
+    :expect  "...[a]...<!>[a]..."
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+;; 通常の isearch-forward-word のテストは、tctest-word-search
+(ert-deftest tctest-isearch-forward-word-with-arg ()
+  "C-u M-s w で通常サーチとなり、line-fold search が有効になる。"
+  (skip-unless tcode-use-isearch)
+  (should-not (tctest-cmp "[IMON] C-u M-s w 単語 [MATCH]"
+    :initial "...英単\n   語...単語"
+    :expect  "...英[単\n   語<!>]...単語"
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-isearch-symbol-at-point ()
+  "M-s . で symbol サーチになる。(line-fold search に上書きされない。)"
+  (should-not (tctest-cmp "M-s . C-s [MATCH]"
+    :initial "let seq-let let"
+    :expect  "let seq-let [let<!>]"
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-isearch-thing-at-point ()
+  "M-s M-. では line-fold search が有効になる。"
+  (skip-unless (and (>= emacs-major-version 28) ; emacs-28 からの機能。
+		    tcode-use-isearch))
+  (should-not (tctest-cmp "M-s M-. C-s [MATCH]"
+    :initial "長い単語 ...長い\n  単語"  ; (thing-at-point 'symbol)がヒット。
+    :expect  "長い単語 ...[長い\n  単語<!>]"
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-word-search-forward ()
+  "word-search-forward が単語サーチになる。(line-fold search に上書きされない。)"
+  (should-not (tctest-cmp "M-x word-search-forward RET [IMON] 単語 RET [MATCH]"
+    :initial "...単\n語 英単語帳 単語"
+    :expect  "...単\n語 英単語帳 [単語<!>]"
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-word-search-backward ()
+  "word-search-backward が単語サーチになる。"
+  (should-not (tctest-cmp
+	       "M-> M-x word-search-backward RET [IMON] 単語 RET [MATCH]"
+    :initial "...単語 単\n語 英単語帳"
+    :expect  "...<!>[単語] 単\n語 英単語帳"
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-word-search-forward-lax ()
+  "word-search-forward-lax が単語サーチになる。"
+  (should-not (tctest-cmp
+	       "M-x word-search-forward-lax RET [IMON] 単語 RET [MATCH]"
+    :initial "...単\n語 英単語帳 単語帳"
+    :expect  "...単\n語 英単語帳 [単語<!>]帳"
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+(ert-deftest tctest-word-search-backward-lax ()
+  "word-search-backward-lax が単語サーチになる。"
+  (should-not (tctest-cmp
+	       "M-> M-x word-search-backward-lax RET [IMON] 単語 RET [MATCH]"
+    :initial "...単語帳 単\n語 英単語帳"
+    :expect  "...<!>[単語]帳 単\n語 英単語帳"
+    :vars '((tcode-isearch-enable-line-fold-search t))))) ; default
+
+;;;
+;;; *その他の input method
+;;;
+
+(ert-deftest tctest-ja-alnum ()
+  "ja-alnum input method で全角英数字が入力できる。"
+  (should-not (tctest-cmp "[IMON] ABCdef123 [IMOFF]"
+    :expect "ＡＢＣｄｅｆ１２３<!>"
+    :requires '(tc-ja-alnum) :input-method "japanese-2byte-alnum")))
+
+;;;
+;;; *undo
+;;;
+
+(ert-deftest tctest-ja-alnum-undo-chars-and-dels ()
+  "ja-alnum input method で削除と文字入力がまとめて undo されない。"
+  ;; 既知の問題: https://github.com/kanchoku/tc/pull/32#issue-3581879791
+  ;; の「Fix undo amalgamation of insertion and deletion」の説明参照。
+  :expected-result :failed
+  (should-not (tctest-cmp "[IMON] June DEL DEL ly [UNDO]"
+    :expect "Ｊｕ<!>"
+    :requires '(tc-ja-alnum) :input-method "japanese-2byte-alnum")))
+
+(ert-deftest tctest-undo-chars-and-dels ()
+  "削除と文字入力がまとめて undo されない。"
+  (should-not (tctest-cmp "[IMON] こんにちは DEL DEL DEL ばんは [UNDO]"
+    :expect "こん<!>")))
+
+(ert-deftest tctest-undo-chars-and-dels1 ()
+  "削除と文字入力がまとめて undo されない。(1文字版)"
+  (should-not (tctest-cmp "[IMON] あ DEL い [UNDO]"
+    :expect "<!>")))
+
+(ert-deftest tctest-undo-char-after-postfix-bushu ()
+  "部首合成後の文字挿入の undo で、文字挿入だけ消える。"
+  (should-not (tctest-cmp "[IMON] イ反 [POSTBUSHU] 想 [UNDO]"
+    :expect "仮<!>")))
+
+;;;
+;;; *event-loop 関連
+;;;
+
+(ert-deftest tctest-kbd-macro-ends-with-postfix-bushu ()
+  "キーボードマクロ実行の最後が部首合成であっても、すぐ終了する。"
+  (should
+   (eq 'success
+       (with-temp-buffer
+	 (switch-to-buffer (current-buffer))
+	 (with-timeout (1 'timeout)
+	   (let ((keys (tctest-key-filter "[IMON] イ反 [POSTBUSHU]")))
+	     (advice-add 'sit-for :around #'tctest-sit-for)
+             (execute-kbd-macro (kbd keys))
+	     (advice-remove 'sit-for #'tctest-sit-for))
+           'success)))))
+
+(ert-deftest tctest-char-after-indent-rigidly ()
+  "indent-rigidly を終了しつつ日本語入力できる。"
+  (should-not (tctest-cmp "[IMON] C-SPC C-n C-n C-x C-i <right> あ SPC"
+    :initial "abc\ndef\n"
+    :expect " abc\n def\nあ <!>")))
+
+(ert-deftest tctest-prefix-arg ()
+  "prefix arg で日本語文字を繰り返せる。"
+  (should-not (tctest-cmp "[IMON] C-u あ"
+    :expect "ああああ<!>")))
+
+(ert-deftest tctest-space-use-previous-prefix-arg ()
+  "交ぜ書き変換後のスペースが前の文字の prefix-arg を引き継がない。"
+  (should-not (tctest-cmp "[IMON] か手 [POSTMAZE] RET C-u あ SPC"
+    :expect "歌手ああああ <!>")))
+
+(ert-deftest tctest-prefix-arg-for-space ()
+  "交ぜ書き変換後、スペースの個数を prefix-arg で指定できる。"
+  (should-not (tctest-cmp "[IMON] か手 [POSTMAZE] RET C-u SPC"
+    :expect "歌手    <!>")))
+
+(defun tctest-pchitc-setup (&rest args)
+  (tcode-set-key "@" 'tctest-pchitc-cmd))
+(defun tctest-pchitc-cmd ()
+  (insert "(cmd)")
+  (add-hook 'post-command-hook 'tctest-pchitc-hook-fun))
+(defun tctest-pchitc-hook-fun ()
+  (remove-hook 'post-command-hook 'tctest-pchitc-hook-fun)
+  (insert "(hook-fun)"))
+(defun tctest-pchitc-cleanup (&rest args)
+  (remove-hook 'post-command-hook 'tctest-pchitc-hook-fun)
+  (tcode-set-key "@" nil))
+(ert-deftest tctest-post-command-hook-in-tc-command ()
+  "tc 内から呼んだコマンド直後に post-command-hook が作動する。"
+  (should-not (tctest-cmp "[IMON] あい @ う"
+    :expect "あい(cmd)(hook-fun)う<!>"
+    :setup-fun #'tctest-pchitc-setup
+    :cleanup-fun #'tctest-pchitc-cleanup)))
+
+;;
+;; *tcode-electric-space, tcode-electric-comma
+;;
+
+(defun tctest-setup-elec (params)
+  (tctest-define-key params tctest-mode-map " " 'tcode-electric-space)
+  (tctest-define-key params tctest-mode-map "," 'tcode-electric-comma))
+
+;; (tc-manual.pdf p.22)
+;;   非 T コードモードから T コードモードへ
+;;     , : カーソルの直前の文字により動作が異なります。行頭または空白な
+;;         らモード切り替え...
+(ert-deftest tctest-elec-comma-at-bol ()
+  "(electric)行頭の「,」で IM オン"
+  (should-not (tctest-cmp ", [MODE]"
+    :expect "[TC]<!>"
+    :setup-fun #'tctest-setup-elec)))
+
+(ert-deftest tctest-elec-comma-after-space ()
+  "(electric)空白文字後の「,」で IM オン"
+  (should-not (tctest-cmp "C-f , [MODE]"
+    :initial " ."
+    :expect " [TC]<!>."
+    :setup-fun #'tctest-setup-elec)))
+
+(ert-deftest tctest-elec-comma-after-tab ()
+  "(electric)タブ文字後の「,」で IM オン"
+  (should-not (tctest-cmp "C-f , [MODE]"
+    :initial "\t."
+    :expect "\t[TC]<!>."
+    :setup-fun #'tctest-setup-elec)))
+
+;; (tc-manual.pdf p.22)
+;;   非 T コードモードから T コードモードへ
+;;     , : ...、それ以外ならそのまま, を挿入します。
+(ert-deftest tctest-elec-comma-after-char ()
+  "(electric)通常文字後の「,」は、IM オフのまま"
+  (should-not (tctest-cmp "C-f , [MODE]"
+    :initial "a."
+    :expect "a,[]<!>."
+    :setup-fun #'tctest-setup-elec)))
+
+;; (tc-manual.pdf p.22)
+;;   非 T コードモードから T コードモードへ
+;;     SPC , : スペースを挿入後、モードを切り替えます。
+(ert-deftest tctest-elec-space-comma ()
+  "(electric)「SPC ,」でスペース挿入後 IM オン。"
+  (should-not (tctest-cmp "SPC , [MODE]"
+    :initial "."
+    :expect " [TC]<!>."
+    :setup-fun #'tctest-setup-elec)))
+
+;; (tc-manual.pdf p.23)
+;;   非 T コードモードから T コードモードへ
+;;     SPC TAB : スペースは、一旦挿入されますが、モードを切り替えた後
+;;               取り除かれます。
+(ert-deftest tctest-elec-space-tab-on ()
+  "(electric)「SPC TAB」でスペース挿入無しで IM オン。"
+  (should-not (tctest-cmp "SPC TAB [MODE]"
+    :expect "[TC]<!>"
+    :setup-fun #'tctest-setup-elec)))
+
+(ert-deftest tctest-elec-space-char ()
+  "(electric)SPC後「a」で IM オフのまま。"
+  (should-not (tctest-cmp "SPC a [MODE]"
+    :expect " a[]<!>"
+    :setup-fun #'tctest-setup-elec)))
+
+;; (tc-manual.pdf p.23)
+;;   T コードモードから非 T コードモードへ
+;;     T コードによる入力の直後 (前置型の交ぜ書き変換中のときを除く)
+;;     では、モード切り替えを行い、かつスペースを挿入します。
+(ert-deftest tctest-elec-kanji-space ()
+  "(electric)「漢 SPC」でスペース挿入かつ IM オフ。"
+  (should-not (tctest-cmp "[IMON] 漢 SPC [MODE]"
+    :expect "漢 [--]<!>"
+    :setup-fun #'tctest-setup-elec)))
+
+;; (tc-manual.pdf p.23)
+;;   T コードモードから非 T コードモードへ
+;;     ...そうでない場合は、そのままスペースを挿入します。
+(ert-deftest tctest-elec-non-kanji-space ()
+  "(electric)IM オン時、C-f SPC 漢 で、空白と「漢」挿入かつ IM オンのまま。"
+  ;; 既知の問題: https://github.com/kanchoku/tc/issues/40
+  :expected-result :failed
+  (should-not (tctest-cmp "[IMON] C-f SPC 漢 [MODE]"
+    :initial "あい"
+    :expect "あ 漢[TC]<!>い"
+    :setup-fun #'tctest-setup-elec)))
+
+;; (tc-manual.pdf p.23)
+;;   T コードモードから非 T コードモードへ
+;;     SPC TAB : スペースは、一旦挿入されますが、モードを切り替えた後
+;;               取り除かれます。
+(ert-deftest tctest-elec-space-tab-off-after-non-char ()
+  "(electric)IM オン時、C-f 後に「SPC TAB」でスペース挿入無しで IM オフ。"
+  ;; 既知の問題: https://github.com/kanchoku/tc/issues/40
+  :expected-result :failed
+  (should-not (tctest-cmp "[IMON] C-f SPC TAB [MODE]"
+    :initial "あい"
+    :expect "あ[--]<!>い"
+    :setup-fun #'tctest-setup-elec)))
+
+(ert-deftest tctest-elec-space-tab-off-after-char ()
+  "(electric)IM オン、文字入力後、「SPC TAB」でスペース挿入無しで IM オフ。"
+  ;; マニュアルでは直前が文字入力かどうかに関係なくオフになるように読
+  ;; めるが、ソースコードでは、そのような実装にはなっていない。マニュ
+  ;; アルとソースコードのどちらが作者の意図かはわからない。
+  ;; https://github.com/kanchoku/tc/issues/40
+  ;; の問題(2)で言及した。既知の問題とする。
+  :expected-result :failed
+  (should-not (tctest-cmp "[IMON] あ SPC TAB [MODE]"
+    :expect "あ[--]<!>"
+    :setup-fun #'tctest-setup-elec)))
+
+;; (tc-manual.pdf p.23)
+;;   たとえば、T コードモードの時に、‘たとえば、Emacs では’ と入力しよ
+;;   うとしたとします。この場合は、‘たとえば、’ の後 SPC を入力し、続
+;;   けて ‘Emacs ’ を入力します。次に、, の後 ‘では’ と入力すればよい
+;;   のです。ここで、句読点の直後では、SPC による切り替えでも空白は挿
+;;   入されません。
+(ert-deftest tctest-elec-example ()
+  "(electric)「たとえば、 Emacs ,では」で SPC と「,」が消える。"
+  (should-not (tctest-cmp "[IMON] たとえば、 SPC Emacs SPC ,では"
+    :expect "たとえば、Emacs では<!>"
+    :setup-fun #'tctest-setup-elec)))
+
+(ert-deftest tctest-elec-kanji-space-without-inserting ()
+  "(electric)「漢 SPC」でIM オフ。without-inserting t なら空白挿入なし。"
+  (should-not (tctest-cmp "[IMON] 漢 SPC [MODE]"
+    :expect "漢[--]<!>"
+    :vars '((tcode-electric-space-without-inserting t))
+    :setup-fun #'tctest-setup-elec)))
+
+(ert-deftest tctest-elec-space-comma-without-inserting ()
+  "(electric)「SPC ,」でIM オン。without-inserting t なら空白挿入なし。"
+  (should-not (tctest-cmp "SPC , [MODE]"
+    :initial "."
+    :expect "[TC]<!>."
+    :vars '((tcode-electric-space-without-inserting t))
+    :setup-fun #'tctest-setup-elec)))
+
+(ert-deftest tctest-elec-space-read-only ()
+  "(electric)read-onlyバッファで「SPC」でIMオン/オフ切り替えできる。"
+  (should-not (tctest-cmp
+	       "C-x C-q SPC C-x C-q [MODE] C-x C-q SPC C-x C-q [MODE]"
+    :initial ""
+    :expect "[TC][--]<!>"
+    :setup-fun #'tctest-setup-elec)))
+
+
+(provide 'tctest)


### PR DESCRIPTION
「emacs 本体の関数の上書きを無くしたい #29」に書いた、advice による isearch 拡張と wrapped-search の実装です。テストも付けました。input method 系の実装は、この commit に追加する形で後日、別 PR にします。

以下、commit log に書ききれなかったコメントです。

#### Reimplement isearch extensions using advice (commit e8391d7)

 - 実装本体です。「isearch-lax-whitespaceが機能しない #25」も自動で直っています。
 - tc-isbushumaze.el の関数は tc-is22.el の部首/交ぜ書き変換関連コードのコピーで、1文字も変えていません。
    + tc-is22.el がこのまま存続し続けるなら、ts-is22.el からもこのファイルをロードする形にするのがよいと思います。
 - tc-ishelper.el の copyright 部分は適当に書いたので確認お願いします。
 - wrapped search の実装には、isearch.el 内の `isearch-define-mode-toggle` というマクロを使いました。これには、「キーバインドを作る」という望んでない機能もついていて、オフにできないのですが、まあいっかと思ってそのままにしてあります。iseach 中に `M-s @` で wrapped search がオンオフできます。
 - `tcode-isearch-start-state` については、#28 の問題を修正した版を入れました。この機能の発案者がどういう意図だったのか(「バッファと独立」とは?)、元の実装がその意図に沿ったものだったのか、いまいちよくわからないのですが、元の実装の挙動を仕様と考えて、DOCSTRING を明確化しました。
    + 値 `t` は無くしてあります。

#### Add a section about isearch extensions to README.md (commit b9a73bc)
 - isearch 実装が選べることを README.md に書きました。

#### Add ert tests for isearch extensions (commit f2c9ab5)
 - テストです。使い方は tctest.el をご覧ください。
 - 将来の input method 方式のテストも含めてあります。そこで改善される問題(多段前置部首変換が可能になるなど)のテストは失敗しますが、既知の問題扱い(`:expected-result` が `:fail`) としてあるので、テスト全体では成功扱いになるはずです。(赤いFマークが出ない)。
 - 以下の設定で、Windows 版 emacs の24〜30の各メジャーバージョンでテストが通る(unexpected な結果が出ない)ことを確認しました。
    + `(setq tcode-use-isearch nil)`
    + `(setq tcode-use-isearch t)`
    + `(setq tcode-use-isearch :advice)`
 - tctest-env.el、run.bash は、自動実行を楽にするためのスクリプトです。各自でやればよい話とも言えますが、せっかく作ったので入れておきました。

以上です。修正点、疑問点等あればお知らせください。些細な問題でも教えていただけるとありがたいです。
