### PR TITLE
tcode-use-input-method のバグ修正と isearch 中の部首/交ぜ書き変換の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ Windowsは日本語環境にしておいた方が無難です。
 
 ## isearch実装の選択
 
-isearch機能のT-Code用拡張は、次の2種類の実装から選ぶことができます。機能の内容や使い方は同じです。
+isearch機能のT-Code用拡張は、次の3種類の実装から選ぶことができます。機能の内容や使い方は同じです。
 
  - 従来実装。Emacsの内部関数の書き換えによってisearch拡張を実現しているため、Emacsに最近追加されたisearch機能が使えなくなる場合があります。`(setq tcode-use-isearch 'overwrite)` とすることで利用できます(デフォルト)。
  - advice機能を用いた実装。Emacs内部関数の書き換えを無くした実装なので、Emacsのバージョンアップによるisearch機能の変化に追従しやすくなっています。`(setq tcode-use-isearch 'advice)` とすることで利用できます。
+ - input method方式による実装。T-Code自体の実装方式を変える実験的な実装です。Emacs内部関数の書き換えを無くし、さらに、バッファ編集中とisearch中で、共通のT-Code実装を用います。一部、上2つの実装とは動作が異なります。例:
+    + isearch中に句読点、カタカナモードの切り換えが可能です(全角英数モードはどの実装でも可能)。
+    + isearch中の前置変換終了後、minibufferを終了させるためのRETキーが不要です。
+    + 多段の前置部首合成変換が可能です。
+
+   `(setq tcode-use-isearch 'im)` とすることで利用できます。

--- a/tc-bushu.el
+++ b/tc-bushu.el
@@ -1055,6 +1055,12 @@ See also `tcode-bushu-functions'."
 
 (defun tcode-bushu-put-prefix ()
   "前置型部首合成変換の開始地点として印を付ける。"
+  (if tcode-bushu-prefix-list ; すでに部首変換中
+      ;; 部首-部首のネストは可
+      (tcode-bushu-put-prefix-core)
+    (tcode--start-prefix-conversion #'tcode-bushu-put-prefix-core)))
+
+(defun tcode-bushu-put-prefix-core ()
   (tcode-bushu-init 2)
   (unless (get-buffer tcode-bushu-expand-buffer-name)
     (error "Bushu dictionary not ready."))
@@ -1073,7 +1079,9 @@ See also `tcode-bushu-functions'."
       (save-excursion
 	(goto-char p)
 	(when (looking-at "▲")
-	  (delete-char 1))))))
+	  (delete-char 1)))))
+  (when (null tcode-bushu-prefix-list) ; ネストも含めて変換完了
+    (tcode--finish-conversion)))
 
 (defun tcode-bushu-clear-prefix ()
   "前置型部首合成変換用の印をすべて削除する。"

--- a/tc-ja-alnum.el
+++ b/tc-ja-alnum.el
@@ -78,8 +78,6 @@
 
 (defun tcode-2byte-alnum-input-method (ch)
   "The 2byte alnum input function for T-Code."
-  (setq last-command 'self-insert-command
-	last-command-event ch)
   (list (tcode-1-to-2 ch)))
 
 (unless (boundp 'input-method-function)

--- a/tc-mazegaki.el
+++ b/tc-mazegaki.el
@@ -1138,7 +1138,8 @@ NOT-QUIT が nil でないときは、読みの状態に戻すだけで、終了
 	      (tcode-mazegaki-construct-yomi
 	       (+ tcode-mazegaki-current-yomi-length
 		  tcode-mazegaki-current-offset)))
-	     (tcode-auto-remove-help-char)))))
+	     (tcode-auto-remove-help-char))
+	(tcode--finish-conversion))))
 
 (add-hook 'tcode-clear-hook 'tcode-mazegaki-finish)
 
@@ -1646,6 +1647,9 @@ CONVERSION が nil でないとき、補完後(補完を行った場合のみ)�
 (defun tcode-mazegaki-put-prefix ()
   "前置型交ぜ書き変換の開始地点の印を付ける。"
   (interactive)
+  (tcode--start-prefix-conversion #'tcode-mazegaki-put-prefix-core))
+
+(defun tcode-mazegaki-put-prefix-core ()
   (setq tcode-mazegaki-prefix (point))
   (add-hook 'post-command-hook 'tcode-mazegaki-put-conversion-face))
 

--- a/tc-pre.el
+++ b/tc-pre.el
@@ -79,6 +79,8 @@ Emacs 内部関数を置き換える関数を提供するモジュール名。")
  nil         : isearch 中にTコードを使用しない。
  `overwrite' : Emacs 内部関数の書き換えによる実装(従来実装)を用いる。
  `advice'    : advice による実装を用いる。
+ `im'        : input method による実装を用いる。
+               `tcode-use-input-method' が自動で t となる。
 デフォルト値は `overwrite'。nil にするには、設定ファイル ~/.tc 内で
 セットする。")
 

--- a/tc-setup.el
+++ b/tc-setup.el
@@ -23,13 +23,14 @@
 ;;; Code:
 
 (require 'tc-pre)
+(defvar tcode-use-input-method)
 
 (defun tcode--load-isearch ()
   "`tcode-use-isearch' の設定に応じて必要なファイルをロードする。"
   (cond ((eq tcode-use-isearch 'overwrite)
          (require 'tc-sysdep)
          (require tcode-isearch-overwrite-module))
-        ((eq tcode-use-isearch 'advice)
+        ((memq tcode-use-isearch '(advice im))
          (require 'tc-ishelper))
         ((eq tcode-use-isearch nil) )  ; do nothing
         (t
@@ -87,6 +88,8 @@
 	(setq-default default-input-method tcode-default-input-method)
 	(setq default-input-method tcode-default-input-method)))
   ;; isearch
+  (when (eq tcode-use-isearch 'im)
+    (setq tcode-use-input-method t))
   (when tcode-use-as-default-input-method
     (tcode--load-isearch))
   ;; autoload

--- a/tc.el
+++ b/tc.el
@@ -746,8 +746,8 @@ t ... cancel"
 	      tcode-display-help-delay tcode-orig-display-help-delay
 	      tcode-input-method-verbose-flag nil)))
   (let ((command (tcode-default-key-binding (char-to-string ch))))
-    (if (or (and (boundp 'overriding-terminal-local-map)
-		 overriding-terminal-local-map)
+    (if (or (and overriding-terminal-local-map
+                (lookup-key overriding-terminal-local-map (vector ch)))
 	    (and (boundp 'overriding-local-map)
 		 overriding-local-map)
 	    (eq this-command 'quoted-insert)

--- a/tc.el
+++ b/tc.el
@@ -686,9 +686,15 @@ t ... cancel"
 
 (defun tcode-input-method (ch)
   "The input method function for T-Code."
-    (if tcode-debug
-	(tcode--input-method-core ch)
-      (tcode--input-method-guard ch)))
+  (let ((events (if tcode-debug
+		    (tcode--input-method-core ch)
+		  (tcode--input-method-guard ch))))
+    (or events
+	(when tcode-use-input-method
+	  ;; input method が nil を返すと、(read-event) やキーボードマク
+	  ;; ロが終了しない。
+	  '(tcode-ignore)))))
+(global-set-key [tcode-ignore] 'ignore)
 
 (defun tcode--input-method-guard (ch)
   ;; isearch 中に input method がエラーを起こすとユーザーの意図しない

--- a/tc.el
+++ b/tc.el
@@ -663,8 +663,9 @@ t ... cancel"
 	 (if (commandp action)
 	     (progn
 	       ;; コマンドの実行
-	       (setq prefix-arg current-prefix-arg
-		     this-command action)
+	       (unless tcode-use-input-method
+		 (setq prefix-arg current-prefix-arg))
+	       (setq this-command action)
 	       (command-execute action))
 	   ;; コマンドでない関数の実行
 	   (funcall action)

--- a/tc.el
+++ b/tc.el
@@ -727,8 +727,7 @@ t ... cancel"
      nil)))
 
 (defun tcode--input-method-core (ch)
-  (setq last-command 'self-insert-command
-	last-command-event ch)
+  (setq last-command-event ch)
   (if input-method-verbose-flag
       (unless tcode-input-method-verbose-flag
 	;; push some variables' values

--- a/tc.el
+++ b/tc.el
@@ -687,7 +687,7 @@ t ... cancel"
 (defun tcode-input-method (ch)
   "The input method function for T-Code."
   (let ((events (if tcode-debug
-		    (tcode--input-method-core ch)
+		    (tcode--input-method-isearch-wrap ch)
 		  (tcode--input-method-guard ch))))
     (or events
 	(when tcode-use-input-method
@@ -704,7 +704,7 @@ t ... cancel"
   ;; tcode-set-key などで、ユーザー指定の任意のコマンドが input method
   ;; 内から実行されうるので、エラー発生を前提とする必要がある。
   (condition-case err
-      (tcode--input-method-core ch)
+      (tcode--input-method-isearch-wrap ch)
     (error
      (ding)
      (minibuffer-message "Error in input method: %S" err)
@@ -782,6 +782,87 @@ t ... cancel"
 	(funcall self-insert-after-hook p (point)))
     (tcode-do-auto-fill)
     (run-hooks 'input-method-after-insert-chunk-hook)))
+
+;;
+;; tcode-use-input-method 有効時の isearch サポート
+;;
+
+;; tcode-use-input-method が非 nil の場合、isearch 中に
+;; tcode-input-method の呼び出しが行なわれる。この呼び出しは、次のよう
+;; に行なわれる。(emacs 本体の isearch-x.el で定義される
+;; isearch-process-search-multibyte-characters と
+;; isearch-with-input-method 参照。)
+;;
+;; (ユーザーが isearch 中に文字キーを打つと、)
+;;  1. これまでのサーチ文字列が minibuffer に書かれる。
+;;  2. minibuffer 内で tcode-input-method が入力文字を引数として呼ばれる。
+;;  3. tcode-input-method が文字のリストを返すと、それが minibuffer
+;;     に追加され、すぐに minibuffer は終了する。
+;;  4. この時点で、minibuffer 内で設定したバッファローカル変数は忘れて
+;;     しまう。また、tcode-input-method 内で isearch 対象バッファの
+;;     point 位置を変更しても、元の位置に戻ってしまう。
+;;  5. minibuffer 文字列の追加部分だけがサーチ文字列に足される。(その
+;;     手前部分を tcode-input-method が変更しても無視される。)
+;;
+;; 後置変換によって minibuffer 文字列が書き換えられても、4.5.の理由で、
+;; 2.の時点では、その結果をサーチ文字列に反映させることも、マッチ位置
+;; にpoint を移動させることもできない。この処理を post-command-hook で
+;; 行なうことで、後置変換を実現する。
+
+(defvar tcode--in-isearch-flag nil
+  "isearch 中かどうか。正確には、isearch 時に用いられる特殊な
+minibuffer から呼び出されているかどうか。tcode-use-input-method が
+nil の場合は常に nil。")
+
+(defun tcode--input-method-isearch-wrap (ch)
+  "tcode-input-method に対し、isearch 中の処理を追加するラッパー"
+  ;; isearch-with-input-method は isearch-x.el 内で定義されたコマンド。
+  ;; minibuffer 内で起動され、tcode-input-method を呼び出す。
+  (if (not (eq this-command 'isearch-with-input-method))
+      ;; isearch 中でない、または、tcode-use-input-method が nil。
+      (tcode--input-method-core ch)
+    ;; isearch 中。
+    (let ((tcode--in-isearch-flag t)
+	  (search-msg-before (minibuffer-contents))
+	  (cur-buf (current-buffer))
+	  (orig-buf (window-buffer (minibuffer-selected-window)))
+	  search-msg-after events)
+      (setq events (tcode--input-method-core ch))
+      (switch-to-buffer cur-buf)
+      (setq search-msg-after (minibuffer-contents))
+      (when (not (string-prefix-p search-msg-before search-msg-after))
+	;; サーチ文字列に追加以外の変更があった。後で反映。
+	(tcode--call-later #'tcode--isearch-update search-msg-after))
+      events)))
+
+(defvar tcode--call-later-queue nil
+  "tcode--call-laterによって実行を予約された関数と引数のキュー。")
+
+(defun tcode--call-later (&rest fun-args)
+  "現在実行中のコマンド終了後に関数呼び出しを行なう。"
+  (push fun-args tcode--call-later-queue)
+  (add-hook 'post-command-hook #'tcode--call-later-worker))
+
+(defun tcode--call-later-worker ()
+  (setq tcode--call-later-queue (nreverse tcode--call-later-queue))
+  (while tcode--call-later-queue
+    (let* ((fun-args (pop tcode--call-later-queue))
+	   (fun (car fun-args))
+	   (args (cdr fun-args)))
+      (apply fun args))))
+
+(defun tcode--isearch-update (msg-after)
+  "tcode-input-method が行なったサーチ文字列の修正を実際に反映する。"
+  (while (not (string-prefix-p isearch-message msg-after))
+    (isearch-delete-char))
+  (tcode--isearch-append (substring msg-after (length isearch-message))))
+
+(defun tcode--isearch-append (str)
+  "サーチ文字列に STR を追加する。"
+  ;; 1文字ずつ消せるよう、1文字ずつサーチ文字列に加える。
+  (dolist (ch (string-to-list str))
+    (let ((s-ch (char-to-string ch)))
+      (isearch-process-search-string s-ch s-ch))))
 
 ;;
 ;; 2バイト英数字

--- a/tc.el
+++ b/tc.el
@@ -684,6 +684,12 @@ t ... cancel"
 キャッチして捨ててしまう。デバッグ時にエラーの backtrace を取得したい場合は、
 この変数を t にセットする。")
 
+(defvar tcode--in-minibuffer-for-conversion-flag nil
+  "isearch 中の前置変換のための minibuffer にいる。")
+
+(defvar tcode--isearch-orig-buf nil
+  "isearch を開始したバッファ。")
+
 (defun tcode-input-method (ch)
   "The input method function for T-Code."
   (let ((events (if tcode-debug
@@ -808,6 +814,13 @@ t ... cancel"
 ;; 2.の時点では、その結果をサーチ文字列に反映させることも、マッチ位置
 ;; にpoint を移動させることもできない。この処理を post-command-hook で
 ;; 行なうことで、後置変換を実現する。
+;;
+;; 前置変換では変換開始位置のバッファローカル変数への記録、文字への下
+;; 線付けが行なわれ、それを複数文字の編集にわたって記憶しておく必要が
+;; ある。isearch-x.el の用意する minibuffer は1文字ごとに終了するので、
+;; それをそのまま用いることはできない。post-command-hookを用いて
+;; minibuffer の終了を待った上で、新たな minibuffer を用意し、その中で
+;; 前置変換を行なう。
 
 (defvar tcode--in-isearch-flag nil
   "isearch 中かどうか。正確には、isearch 時に用いられる特殊な
@@ -863,6 +876,57 @@ nil の場合は常に nil。")
   (dolist (ch (string-to-list str))
     (let ((s-ch (char-to-string ch)))
       (isearch-process-search-string s-ch s-ch))))
+
+(defun tcode--start-prefix-conversion (fun)
+  "前置変換の開始関数を呼ぶ。isearch 中の場合 minibuffer 内で呼ぶ。"
+  (if tcode--in-minibuffer-for-conversion-flag
+      (minibuffer-message "isearch 中の前置変換はネストできません。")
+    (if tcode--in-isearch-flag
+	(tcode--with-minibuffer fun)
+      (funcall fun))))
+
+(defun tcode--with-minibuffer (fun)
+  "isearch 中の前置変換のための minibuffer を用意する。"
+  ;; isearch からの input method の呼び出しに minibuffer を使っている
+  ;; ので、それが終わってから。
+  (tcode--call-later #'tcode--with-minibuffer-deferred fun))
+
+(defun tcode--with-minibuffer-deferred (fun)
+  (let ((old-msg isearch-message)
+	(old-str isearch-string)
+	new-str)
+    (setq tcode--isearch-orig-buf (current-buffer))
+    ;; minibuffer 使用中にバッファを移動して isearch を使用しても、状
+    ;; 態が壊れないようにする。isearch-edit-string にならった。
+    (with-isearch-suspended
+     (minibuffer-with-setup-hook fun	; second
+       (minibuffer-with-setup-hook #'tcode--minibuffer-setup ; first
+	 (setq new-str (read-string (concat "Isearch read: " old-msg)
+				    nil nil nil t))
+	 (when (> (length new-str) 0)
+	   ;; 先頭文字だけサーチ文字列に追加
+	   (let ((ch (substring new-str 0 1)))
+	     ;; 部首/交ぜ書き変換でコントロール文字は扱わないとの仮定のもと、
+	     ;; string と message は同じ。
+	     (setq isearch-new-string  (concat old-str ch))
+	     (setq isearch-new-message (concat old-msg ch)))))))
+    (when (> (length new-str) 1)
+      (tcode--isearch-append (substring new-str 1)))))
+
+(defun tcode--minibuffer-setup ()
+  (setq-local tcode--in-minibuffer-for-conversion-flag t))
+
+(defun tcode--finish-conversion ()
+  "isearch 内前置変換の終了処理。必要なら minibuffer から出る。"
+  (when tcode--in-minibuffer-for-conversion-flag
+    ;; exit-minibuffer は大域脱出なので、呼び出し側関数が全て終ってから。
+    (tcode--call-later #'tcode--finish-conversion-deferred)))
+
+(defun tcode--finish-conversion-deferred ()
+  ;; tcode--finish-conversion が複数回呼ばれてもよいよう、minibuffer
+  ;; 内にいることを確認する。
+  (when tcode--in-minibuffer-for-conversion-flag
+    (exit-minibuffer)))
 
 ;;
 ;; 2バイト英数字

--- a/tc.el
+++ b/tc.el
@@ -330,6 +330,13 @@ nil のときは `tcode-mode' から得る。")
 
 (defvar tcode-katakana-mode nil "現在カタカナモードかどうか")
 (make-variable-buffer-local 'tcode-katakana-mode)
+
+(defvar tcode--mode-vars '(tcode-kuten
+			   tcode-touten
+			   tcode-alnum-2-byte
+			   tcode-katakana-mode
+			   tcode-current-switch-table)
+  "モードを保持する buffer local 変数。")
 
 ;;
 ;; キー配置・キーマップの設定
@@ -697,6 +704,9 @@ t ... cancel"
 		  (tcode--input-method-guard ch))))
     (or events
 	(when tcode-use-input-method
+	  (when tcode--in-minibuffer-for-conversion-flag
+	    ;; events が空なので文字入力ではない。モード変更かもしれない。
+            (tcode--writeback-mode-vars tcode--isearch-orig-buf))
 	  ;; input method が nil を返すと、(read-event) やキーボードマク
 	  ;; ロが終了しない。
 	  '(tcode-ignore)))))
@@ -810,6 +820,10 @@ t ... cancel"
 ;;  5. minibuffer 文字列の追加部分だけがサーチ文字列に足される。(その
 ;;     手前部分を tcode-input-method が変更しても無視される。)
 ;;
+;; 2.より、tcode-input-method 内でバッファローカル変数を参照しても、新
+;; しく作られた minibuffer の値を参照してしまう。句読点や全角/半角英数
+;; モードの設定はバッファローカルなので、事前にコピーしておく必要がある。
+;;
 ;; 後置変換によって minibuffer 文字列が書き換えられても、4.5.の理由で、
 ;; 2.の時点では、その結果をサーチ文字列に反映させることも、マッチ位置
 ;; にpoint を移動させることもできない。この処理を post-command-hook で
@@ -840,13 +854,39 @@ nil の場合は常に nil。")
 	  (cur-buf (current-buffer))
 	  (orig-buf (window-buffer (minibuffer-selected-window)))
 	  search-msg-after events)
+      (tcode--fetch-mode-vars orig-buf)
       (setq events (tcode--input-method-core ch))
       (switch-to-buffer cur-buf)
+      (tcode--writeback-mode-vars orig-buf)
       (setq search-msg-after (minibuffer-contents))
       (when (not (string-prefix-p search-msg-before search-msg-after))
 	;; サーチ文字列に追加以外の変更があった。後で反映。
 	(tcode--call-later #'tcode--isearch-update search-msg-after))
       events)))
+
+(defun tcode--copy-local-vars (from-buf to-buf vars)
+  "FROM-BUF のバッファローカル変数を TO-BUF にコピーする。
+VARS はコピーする変数のリスト。TO-BUF 側の値に変化があれば t、
+なければ nil を返す。"
+  (let ((changed nil))
+    (with-current-buffer to-buf
+      (dolist (var vars)
+	(let ((old-val (symbol-value var))
+	      (new-val (buffer-local-value var from-buf)))
+	  (unless (eql new-val old-val)
+	    (setq changed t)
+	    (set var new-val)))))
+    changed))
+
+(defun tcode--fetch-mode-vars (buffer)
+  "BUFFER のモード状態をカレントバッファにコピーする。"
+  (tcode--copy-local-vars buffer (current-buffer) tcode--mode-vars))
+
+(defun tcode--writeback-mode-vars (buffer)
+  "カレントバッファのモード状態を BUFFER にコピーする。"
+  (when (tcode--copy-local-vars (current-buffer) buffer tcode--mode-vars)
+    (with-current-buffer buffer
+      (tcode-mode-line-redisplay))))
 
 (defvar tcode--call-later-queue nil
   "tcode--call-laterによって実行を予約された関数と引数のキュー。")
@@ -914,6 +954,7 @@ nil の場合は常に nil。")
       (tcode--isearch-append (substring new-str 1)))))
 
 (defun tcode--minibuffer-setup ()
+  (tcode--fetch-mode-vars tcode--isearch-orig-buf)
   (setq-local tcode--in-minibuffer-for-conversion-flag t))
 
 (defun tcode--finish-conversion ()

--- a/test/tctest.el
+++ b/test/tctest.el
@@ -799,9 +799,6 @@
 
 (ert-deftest tctest-ja-alnum-undo-chars-and-dels ()
   "ja-alnum input method で削除と文字入力がまとめて undo されない。"
-  ;; 既知の問題: https://github.com/kanchoku/tc/pull/32#issue-3581879791
-  ;; の「Fix undo amalgamation of insertion and deletion」の説明参照。
-  :expected-result :failed
   (should-not (tctest-cmp "[IMON] June DEL DEL ly [UNDO]"
     :expect "Ｊｕ<!>"
     :requires '(tc-ja-alnum) :input-method "japanese-2byte-alnum")))
@@ -960,8 +957,6 @@
 ;;     ...そうでない場合は、そのままスペースを挿入します。
 (ert-deftest tctest-elec-non-kanji-space ()
   "(electric)IM オン時、C-f SPC 漢 で、空白と「漢」挿入かつ IM オンのまま。"
-  ;; 既知の問題: https://github.com/kanchoku/tc/issues/40
-  :expected-result :failed
   (should-not (tctest-cmp "[IMON] C-f SPC 漢 [MODE]"
     :initial "あい"
     :expect "あ 漢[TC]<!>い"
@@ -973,8 +968,6 @@
 ;;               取り除かれます。
 (ert-deftest tctest-elec-space-tab-off-after-non-char ()
   "(electric)IM オン時、C-f 後に「SPC TAB」でスペース挿入無しで IM オフ。"
-  ;; 既知の問題: https://github.com/kanchoku/tc/issues/40
-  :expected-result :failed
   (should-not (tctest-cmp "[IMON] C-f SPC TAB [MODE]"
     :initial "あい"
     :expect "あ[--]<!>い"


### PR DESCRIPTION
「emacs 本体の関数の上書きを無くしたい #29」の実装の続き、input method 方式での実装です。「isearch拡張機能のadviceによる再実装 #30」の commit に続ける形の commit 群です。#30 で修正が入ったら、こちらも取り換えます。(#30 が済んでからこちらを提出してもよかったのですが、早めに全体像が見えていた方がよいかとも思い、先に提出します。これで私が予定していた修正は全てです。)

### 修正内容の説明

バグ修正2つ、後置部首/交ぜ書き変換の実装、前置部首/交ぜ書き変換の実装、バグ修正3つ、README修正、テスト追加、という順の9個の commit です。

いくつかのバグは、`tcode-input-method` の実行タイミングが変わることに起因します。その説明を #29 に書いておきました。

以下、commit log に書ききれなかったコメントです。特に従来実装に影響が無いかについて検討します。

#### Handle errors in input method to prevent isearch breakage (commit 3187239)

isearch 中にエラーが起きるとわけのわからないモードになって開発がしにくいので、最初にこの修正を入れました。

エラーを起こさなければ従来実装と同じ挙動です。

#### Fix non-terminating kbd macro when bushu conversion occurs last (commit 4935d2b)

`input-method-function` が `nil` を返すのはあまり望ましくないようです。代わりに、ダミーのイベント `tcode-ignore` を返し、次のように何もしないコマンド `ignore` にバインドしました。

```elisp
(global-set-key [tcode-ignore] 'ignore)
```

`global-map` は交換可能なので、デフォルトの `global-map` でバインドするだけでは不十分なのでは? とも考えたのですが、`global-map` を取り換えるコードを emacs ソースから探したところ、Calc や edt (古いエディタのエミュレータ) など、日本語入力をしなさそうな状況のものばかりなので、問題ないと考えました。

`tcode-use-input-method` が `nil` のときは従来通り `nil` を返します。

#### Add isearch support for tcode-use-input-method (commit ef576d5)

`(setq tcode-use-isearch :im)` で input method 方式の isearch になるようにしました。

この commit では、後置部首/交ぜ書き変換まで実装しています。isearch 中の特殊な `input-method-function` の呼び出しの事情については、コード内のコメントで説明しています。

tc-bushu.el、tc-mazegaki.el に全く変更が無い点がセールスポイントです。

従来コードと比べると、ラッパーを挟んでいるだけです。`this-command` が `isearch-with-input-method` でない限り従来と同じコードパスを通ります。`isearch-with-input-method` が呼ばれるのは、`isearch-process-search-multibyte-characters` から。`isearch-process-search-multibyte-characters` が呼ばれるのは `isearch-printing-char` からですが、tc-is22.el でも、advice 方式でも、T-Code モードの場合はその呼び出しを通りません。

#### Implement prefix-bushu/mazegaki conversion in isearch (commit 5fcc755)

前置部首/交ぜ書き変換の実装です。tc-bushu.el、tc-mazegaki.el の変更は、変換開始関数にラッパーを挟んだのと、終了を知らせる関数呼び出しを追加したのみです。

前者(変換開始関数のラッパー)は、`tcode--in-isearch-flag` が立っていないときは何もしません。`tcode--in-isearch-flag` を立てるのは、前 commit のラッパーで isearch 中と判断したときですが、これは従来実装では通らないコードでした。後者(変換終了を知らせる関数)は、`tcode--in-minibuffer-for-conversion-flag` が立っていないときは何もしません。このフラグが立つのは、変換開始時に `tcode--in-isearch-flag` が立っていたときのみ通るコードです。結局、従来実装では新規コードの部分を通りません。

#### Fix undo amalgamation of insertion and deletion (commit 6c60284)

tc-ja-alnum input method と T-Code input method でどちらも `last-command` をセットしているのですが、不要と考え削除しました。`last-command` というのは、input method が呼ばれる前のコマンドで、例えばカーソル移動かも知れませんし、ファイルのセーブかも知れません。input method とは関係がありません。削除しないと、前の編集コマンドが文字挿入とみなされ、これから行なう挿入と一緒に undo されてしまいます。

tc-ja-alnum input method は小さいので、内部で `last-command` を用いていないのは明らかです(同時にセットしている `last-command-event` も用いていません)。T-Code input method も調べたところで内部では `last-command` を使ってなさそうです。`last-command-event` は、内部から呼ばれるサブコマンドで使用しているので、そのままにしてあります。

`last-command` は、次のコマンドが始まる前に `this-command` の値で上書きされてしまうので、内部で使っていないとすると、あと参照するタイミングは何かのフックぐらいしかなさそうです。ちょうど、tc-complete.el の completion 機能が `post-command-hook` を使ってその中で `last-command` を参照しているので、これとの連絡のために `last-command` を流用していたのだと推測しています。tc-complete.el はコードが壊れていて現状動作しないので、これへの影響を考える必要は現時点ではなさそうです。

この修正は、従来実装が通る部分の動作を変更しています。`(unless tcode-use-input-method ...)` として従来実装への影響を無くすこともできますが、上に述べた話でつじつまが合うことから、そこまでする必要もないかと考えました。

#### Fix handling of overriding-terminal-local-map (commit a0f2c27)

`C-u 人` で「人」が4つ表示されるはずが、「m」が4つ表示されてしまいます。ほかにも `set-transient-map` された状況はすべて同様の問題があります。quail のコードを真似て修正しました。

これも従来実装で通る部分の修正ですが、input method 方式でこの修正に問題が無いのであれば、マイナーモード方式ではもっと安全のはずです。transient-map はもう解除されているはずですし、そもそも `tcode-self-insert-command` がコマンドとして実行中ということは、キーマップを参照するフェーズはもう済んでいるわけですから、このタイミングでキーマップの存在によって動作を変える必要性があるとは考えにくいです。

#### Fix SPC insertion being affected by previous prefix argument (commit 9b25833)

input method 方式で `current-prefix-arg` が使えないという #29 で説明したそのままの問題です。

`if` 文により、従来実装では従来通りの動作です。

#### Update README.md: add :im to the list of isearch options (commit 3c55356)

README.md に `:im` の説明を追加しました。

#### Add tests (commit 725c63c)

いくつか細かい挙動のテストを追加しました。

### 2実装の比較

片方だけ採用される可能性もあると思い、`:advice` 方式と `:im` 方式の利点・欠点を比較してみました。

 - `:advice` 方式、`:im` 方式 共通の利点
    * emacs 本体の関数を書き換えている部分が無くなった。
    * (その帰結として) emacs 側の新機能(`isearch-lax-whitespace` ぐらい?)が動作するようになった。
 - `:advice` 方式 の利点
    * コードが tc-is22.el のものとほとんど同じ(wrapped-search 部分を除いて)なので、従来と同様の動作が期待できる。
    * 新規コードが少ないのでレビューの手間が少ない。(tc-ishelper.el と、数行のロードファイル切り換え部分のみ)
 - `:advice` 方式 の欠点(従来のtc-is22.elから欠点ではあるが。)
    * `tcode-input-method`、部首/交ぜ書き変換のコードの一部が、isearch 用に2重に実装されている。
 - `:im` 方式 の利点
    * isearch中の部首/交ぜ書き変換のコードは、通常時と同一のもの用いる。このため、isearch 中の一部機能に改善がある(多重の前置部首変換、交ぜ書き変換確定後の RET が不要に。)
    * 一部 isearch 中使えなかった機能が使えるようになる。(カタカナモード切り換え、句読点切り換え)
    * 一応、`input-method-function` という、input method 実装のための正規の機能を使った実装になっている。
 - `:im` 方式 の欠点
    * 修正が大きい。
    * 使用実績が少なく、まだバグがどんどん出てくるフェーズのはず。
    * `input-method-function` に許されている以上のふるまいをしている感がある(後置変換によるバッファ改変、前置変換のための minibuffer 使用など)。そのために「hack」的な無理をしているとも言える(`post-command-hook` の多用)。